### PR TITLE
fix: shiiman-google スコープ不一致によるAPI呼び出しエラーを修正

### DIFF
--- a/plugins/shiiman-google/.claude-plugin/plugin.json
+++ b/plugins/shiiman-google/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-google",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Google Workspace 操作（認証、Drive/Docs/Sheets/Slides/Forms/Apps Script、Calendar、Gmail）",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-google/scripts/google_apps_script.py
+++ b/plugins/shiiman-google/scripts/google_apps_script.py
@@ -44,7 +44,7 @@ except ImportError:
 
 SCOPES = [
     "https://www.googleapis.com/auth/script.projects",
-    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive",
 ]
 
 

--- a/plugins/shiiman-google/scripts/google_docs.py
+++ b/plugins/shiiman-google/scripts/google_docs.py
@@ -47,7 +47,7 @@ except ImportError:
 
 SCOPES = [
     "https://www.googleapis.com/auth/documents",
-    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive",
 ]
 
 

--- a/plugins/shiiman-google/scripts/google_forms.py
+++ b/plugins/shiiman-google/scripts/google_forms.py
@@ -49,7 +49,7 @@ except ImportError:
 SCOPES = [
     "https://www.googleapis.com/auth/forms.body",
     "https://www.googleapis.com/auth/forms.responses.readonly",
-    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive",
 ]
 
 

--- a/plugins/shiiman-google/scripts/google_sheets.py
+++ b/plugins/shiiman-google/scripts/google_sheets.py
@@ -50,7 +50,7 @@ except ImportError:
 
 SCOPES = [
     "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive",
 ]
 
 

--- a/plugins/shiiman-google/scripts/google_slides.py
+++ b/plugins/shiiman-google/scripts/google_slides.py
@@ -47,7 +47,7 @@ except ImportError:
 
 SCOPES = [
     "https://www.googleapis.com/auth/presentations",
-    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive",
 ]
 
 


### PR DESCRIPTION
## 概要

shiiman-google プラグインで、各スクリプトが要求するスコープとログイン時に保存されるスコープが不一致のため、Sheets/Docs/Slides/Forms/Apps Script の API 呼び出しがエラーになる問題を修正しました。

## 変更内容

- google_sheets.py のスコープを `drive.file` → `drive` に変更
- google_docs.py のスコープを `drive.file` → `drive` に変更
- google_slides.py のスコープを `drive.file` → `drive` に変更
- google_forms.py のスコープを `drive.file` → `drive` に変更
- google_apps_script.py のスコープを `drive.file` → `drive` に変更
- plugin.json のバージョンを 1.2.1 に更新

## 関連 Issue

Closes #36

## テスト計画

- [ ] 既存のトークンで google_sheets.py が動作することを確認
- [ ] 再認証なしで Sheets データを取得できることを確認