### PR TITLE
fix: shiiman-google の認証スコープ不足を修正

### DIFF
--- a/plugins/shiiman-google/scripts/google_auth.py
+++ b/plugins/shiiman-google/scripts/google_auth.py
@@ -24,10 +24,13 @@ DEFAULT_SCOPES = [
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/presentations",
-    "https://www.googleapis.com/auth/forms",
+    "https://www.googleapis.com/auth/forms.body",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
     "https://www.googleapis.com/auth/script.projects",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.compose",
 ]
 
 


### PR DESCRIPTION
## 概要

`google_auth.py` の DEFAULT_SCOPES に一部のスコープが不足していたため、認証後も Gmail/Forms API 呼び出しでスコープ不一致エラー (`invalid_scope: Bad Request`) が発生する問題を修正。

## 変更内容

- Forms: `forms` → `forms.body`, `forms.responses.readonly` に変更
- Gmail: `gmail.send`, `gmail.compose` を追加

## 関連 Issue

Closes #42

## テスト計画

- [ ] 再認証後、Gmail API (search, send, draft) が正常に動作する
- [ ] 再認証後、Forms API (create, get, responses) が正常に動作する