### PR TITLE
feat: settings.json permissions を最適化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,8 @@
     ],
     "deny": [
       "Bash(rm -rf:*)",
+      "Bash(rm -r -f:*)",
+      "Bash(rm -fr:*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
       "Bash(git reset --hard:*)",
@@ -34,6 +36,9 @@
       "Bash(git rebase:*)",
       "Bash(gh repo delete:*)",
       "Bash(chmod 777:*)",
+      "Bash(chmod -R 777:*)",
+      "Bash(chmod 0777:*)",
+      "Bash(chmod -R 0777:*)",
       "Bash(sudo:*)"
     ]
   },


### PR DESCRIPTION
## 概要

dev-flow がスムーズに実行できるよう permissions を整備し、危険なコマンドを deny に追加してセキュリティを強化。

## 変更内容

- settings.json に git/gh/python コマンドの allow を追加
- settings.json に危険なコマンドの deny を追加
  - `rm -rf`, `git push --force/-f`, `git reset --hard`, `git clean -fd`, `git rebase`, `gh repo delete`, `chmod 777`, `sudo`
- `git push` は allow から除外（確認を残す）

## 関連 Issue

Closes #46

## テスト計画

- [ ] dev-flow 実行時に git push 以外で確認が不要になることを確認
- [ ] deny に追加したコマンドがブロックされることを確認