### PR TITLE
chore(shiiman-workflow): バージョンを 1.2.0 に更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェントでの Issue 管理付き・なしのフローを提供",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェントでの Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"


### PR DESCRIPTION
## 概要

#99 で `shiiman-workflow` プラグインの `multi-flow` / `multi-issue-flow` スキルを修正したが、バージョン更新が漏れていたため追加。

## 変更内容

- `plugins/shiiman-workflow/.claude-plugin/plugin.json`: 1.1.0 → 1.2.0
- `.claude-plugin/marketplace.json`: 1.1.0 → 1.2.0

## 関連

- #99