### PR TITLE
feat(shiiman-workflow): タスク完了時のターミナル自動終了機能を追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェントでの Issue 管理付き・なしのフローを提供",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェントでの Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
@@ -430,11 +430,27 @@ mcp__multi-agent-mcp__remove_worktree を呼び出し
 - `worktree_path`: Worker の worktree パス
 - `force`: true（必要に応じて）
 
-**16.2 ワークスペースのクリーンアップ**:
+**16.2 全タスク完了チェック**:
 
 ```
-mcp__multi-agent-mcp__cleanup_workspace を呼び出し
+mcp__multi-agent-mcp__check_all_tasks_completed を呼び出し
 ```
+
+**確認項目**:
+
+- 全タスクが completed 状態であることを確認
+- 未完了タスクがある場合は警告を表示
+
+**16.3 ワークスペースのクリーンアップ（ターミナル自動終了）**:
+
+```
+mcp__multi-agent-mcp__cleanup_on_completion を呼び出し
+```
+
+**動作**:
+
+- 全タスク完了時にワークスペースをクリーンアップ
+- ターミナルウィンドウを自動的に閉じる
 
 ### ステップ 17: セキュリティチェック＆自己レビュー
 

--- a/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
@@ -485,11 +485,27 @@ mcp__multi-agent-mcp__remove_worktree を呼び出し
 - `worktree_path`: Worker の worktree パス
 - `force`: true（必要に応じて）
 
-**18.2 ワークスペースのクリーンアップ**:
+**18.2 全タスク完了チェック**:
 
 ```
-mcp__multi-agent-mcp__cleanup_workspace を呼び出し
+mcp__multi-agent-mcp__check_all_tasks_completed を呼び出し
 ```
+
+**確認項目**:
+
+- 全タスクが completed 状態であることを確認
+- 未完了タスクがある場合は警告を表示
+
+**18.3 ワークスペースのクリーンアップ（ターミナル自動終了）**:
+
+```
+mcp__multi-agent-mcp__cleanup_on_completion を呼び出し
+```
+
+**動作**:
+
+- 全タスク完了時にワークスペースをクリーンアップ
+- ターミナルウィンドウを自動的に閉じる
 
 ### ステップ 19: Owner が VSCode 拡張に結果を返す
 


### PR DESCRIPTION
## 概要

multi-agent-mcp に追加された新しいツールを使用して、タスク終了後にターミナルを自動的に閉じる機能を追加。

## 変更内容

- multi-flow, multi-issue-flow スキルの Phase 4 クリーンアップ部分に以下を追加:
  - `check_all_tasks_completed` - 全タスク完了チェック
  - `cleanup_on_completion` - ターミナル自動終了付きクリーンアップ
- プラグインバージョンを 1.2.0 → 1.3.0 に更新

## テスト計画

- [ ] `/multi-flow` スキルを実行し、タスク完了後にターミナルが閉じることを確認
- [ ] `/multi-issue-flow` スキルを実行し、タスク完了後にターミナルが閉じることを確認

Closes #101