### PR TITLE
shiiman-workflow: SKILL.md スリム化 + 新機能追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェントでの Issue 管理付き・なしのフローを提供",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェントでの Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
@@ -15,65 +15,31 @@ MCP マルチエージェントで Issue/PR なしに並列実行する軽量フ
 - multi-agent-mcp がインストール済み（**必須**）
 - tmux がインストール済み（**必須**）
 
-**確認方法**:
-
-```bash
-which tmux
-claude mcp list | grep multi-agent-mcp
-```
-
 ## 引数
 
 - `--plan`: plan mode で計画書を新規作成してから実行
 - `--workers N`: Worker 数を指定（省略時はプロファイル設定に従う）
 - `--profile standard|performance`: モデルプロファイル選択
-  - `standard`（デフォルト）: Sonnet、Worker 上限 6
-  - `performance`: Opus、Worker 上限 16（複雑なタスク向け）
 - `--help`: ヘルプを表示
 - `[タスク説明]`: 計画書なしで直接実行（簡単なタスク用）
 
-## アーキテクチャ
-
-```
-┌───────────────────────────────────────────────────────────────────┐
-│                    tmux セッション (main)                          │
-├─────────────────┬────────────┬────────────┬────────────┐
-│     pane 0      │   pane 1   │   pane 3   │   pane 5   │
-│     Admin       │    W1      │    W3      │    W5      │
-│     (40%)       ├────────────┼────────────┼────────────┤
-│ (タスク分割・   │   pane 2   │   pane 4   │   pane 6   │
-│  管理)          │    W2      │    W4      │    W6      │
-└─────────────────┴────────────┴────────────┴────────────┘
-     左40%              右60% (Workers 1-6, 3列×2行)
-```
-
-**役割分担**:
-
-| 役割   | 実行者                          | 責務                               |
-| ------ | ------------------------------- | ---------------------------------- |
-| Owner  | 起点 Claude Code（tmux なし）   | 全体指揮、Admin の管理、結果の確認 |
-| Admin  | tmux pane 0                     | タスク分割、Worker 管理、進捗監視  |
-| Worker | tmux pane 1-6+                  | タスク実行、worktree で作業        |
-
-## 3つの実行モード
-
-1. **計画書実行モード**（引数なし）: 既存の承認済み計画書から実行
-2. **計画書作成モード**（`--plan`）: plan mode で計画書を作成してから実行
-3. **直接実行モード**（タスク説明あり）: 計画書なしで直接実行
-
-## 実行フロー概要
+## 実行フロー
 
 ```
 Phase 1: Owner  → ブランチ作成 → MCP 初期化 → Admin 起動 → 計画書送信
-Phase 2: Admin  → タスク分割 → Worker 作成・管理（自律実行）
-Phase 3: Worker → タスク実行 → Admin に報告（自律実行）
-Phase 4: Admin  → 品質チェック → 問題あれば修正タスク作成 → Phase 2 に戻る（ループ）
+Phase 2-4: Admin/Worker が自律実行（MCP が自動制御）
 Phase 5: Owner  → 結果確認 → クリーンアップ → コミットメッセージ出力
+```
+
+## Owner の役割（MCP から取得）
+
+```
+mcp__multi-agent-mcp__get_role_guide(role="owner")
 ```
 
 ---
 
-## Phase 1: セットアップ + Admin 起動（Owner が実行）
+## Phase 1: セットアップ + Admin 起動
 
 ### ステップ 1: ブランチ作成
 
@@ -85,191 +51,71 @@ git checkout -b feature/{slug}
 git push -u origin feature/{slug}
 ```
 
-**slug の生成ルール**: タスク内容から簡潔な英語キーワードに変換（例: `multi-file-refactor`）
+**slug の生成ルール**: タスク内容から簡潔な英語キーワードに変換
 
 ### ステップ 2: MCP ワークスペース初期化
 
 ```
-mcp__multi-agent-mcp__init_workspace
+mcp__multi-agent-mcp__init_workspace(workspace_path="プロジェクト名")
 ```
-
-- `workspace_path`: プロジェクト名
 
 ### ステップ 3: tmux ワークスペース作成
 
 ```
-mcp__multi-agent-mcp__init_tmux_workspace
+mcp__multi-agent-mcp__init_tmux_workspace(
+    working_dir="プロジェクトのルートパス",
+    open_terminal=true,
+    auto_setup_gtr=true
+)
 ```
 
-- `working_dir`: プロジェクトのルートパス
-- `open_terminal`: true
-- `auto_setup_gtr`: true（gtr 自動設定）
-
-**自動作成**: `memory/`, `screenshot/` ディレクトリと `.env` テンプレートが自動生成されます。
-
-### ステップ 3.5: モデルプロファイル設定（`--profile` 指定時）
+### ステップ 3.5: モデルプロファイル設定（`--profile` 指定時のみ）
 
 ```
-mcp__multi-agent-mcp__switch_model_profile
+mcp__multi-agent-mcp__switch_model_profile(profile="standard" or "performance")
 ```
 
-- `profile`: "standard" または "performance"
-
-**注意**: `--profile performance` 指定時のみ実行。Worker 上限 16、Opus モデルに切替。
-
-### ステップ 4: Owner エージェント登録
+### ステップ 4: エージェント作成
 
 ```
-mcp__multi-agent-mcp__create_agent
+mcp__multi-agent-mcp__create_agent(role="owner", working_dir="パス")
+mcp__multi-agent-mcp__create_agent(role="admin", working_dir="パス")
 ```
 
-- `role`: "owner"
-- `working_dir`: プロジェクトのルートパス
-
-**注意**: Owner は tmux ペインなし。IPC 自動登録 + メトリクス記録開始。
-
-### ステップ 5: Admin エージェント作成
+### ステップ 5: Admin に計画書を送信
 
 ```
-mcp__multi-agent-mcp__create_agent
+mcp__multi-agent-mcp__send_task(
+    agent_id="Admin の ID",
+    task_content="計画書またはタスク説明",
+    session_id="ブランチの slug",
+    worker_count=N,
+    branch_name="feature/{slug}"
+)
 ```
 
-- `role`: "admin"
-- `working_dir`: プロジェクトのルートパス
-
-**注意**: tmux pane 0 に配置。IPC 自動登録 + メトリクス記録開始。
-
-### ステップ 6: Admin に計画書を送信
+### ステップ 6: Admin の完了を待機
 
 ```
-mcp__multi-agent-mcp__send_task
-```
-
-- `agent_id`: Admin の ID
-- `task_content`: 計画書またはタスク説明
-- `session_id`: ブランチの slug
-- `worker_count`: Worker 数（省略時はプロファイル設定、`--workers` 指定時はその値）
-- `branch_name`: 作業ブランチ名
-
-**自動処理**: MCP が Admin 用の指示テンプレートを自動生成（Worker 管理手順、メモリ検索結果を含む）
-
-### ステップ 7: Admin の完了を待機
-
-Admin が自律的に Worker を作成・管理。Owner は完了報告を待つ。
-
-```
-mcp__multi-agent-mcp__get_dashboard_summary  # 進捗確認（軽量）
-mcp__multi-agent-mcp__read_messages          # Admin からのメッセージ確認
+mcp__multi-agent-mcp__get_dashboard_summary()
+mcp__multi-agent-mcp__read_messages()
 ```
 
 ---
 
-## Phase 2-3: Admin/Worker の自律実行
+## Phase 2-4: Admin/Worker の自律実行
 
-**Admin と Worker は自律的に動作します。Owner は実行しません。**
-
-### Admin の役割
-
-1. 計画書からサブタスクを抽出し Dashboard に登録
-2. スクリーンショット確認（UI タスクの場合、`read_latest_screenshot` で視覚的問題を分析）
-3. Worker 用 Worktree を作成
-4. Worker エージェントを作成・タスク送信
-5. 進捗を監視
-6. **品質チェック**: Worker 完了後に動作確認（アプリ実行、テスト実行）
-7. **イテレーション**: 問題があれば修正タスクを作成し Worker に再割り当て
-8. 品質チェックをパスしたら Owner に報告
-
-### Worker の役割
-
-1. 指示されたタスクを実装
-2. コミット・プッシュし、ベースブランチにマージ
-3. Admin に完了報告
-
-**MCP 自動処理**:
-- `send_task`: 7セクション構造、ペルソナ、メモリ検索を自動統合
-- `report_task_completion`: メモリ保存、メトリクス更新を自動実行
+**MCP が自動制御。Owner は待機のみ。**
 
 ---
 
-## Phase 4: 品質チェック・イテレーション（Admin が自律実行）
-
-### 品質チェックの流れ
-
-1. **動作確認**: Worker 完了後、アプリを実行してテスト
-
-   ```bash
-   git pull origin {branch_name}
-   npm start  # または python main.py など
-   ```
-
-2. **UI 確認**（UI タスクの場合）:
-   - `read_latest_screenshot` で視覚的確認
-   - 期待通りの表示か確認
-
-3. **問題発見時**: 修正タスクを作成してイテレーション
-
-   ```
-   while (品質に問題あり):
-       1. 問題を分析・リスト化
-       2. create_task で修正タスク登録
-       3. Worker に send_task で修正依頼
-       4. Worker 完了を待機
-       5. 再度品質チェック
-   ```
-
-### イテレーションのルール
-
-- 1回のイテレーションで1-2個の問題に絞る
-- 同じ問題が3回以上繰り返される場合は Owner に相談
-- 修正内容は `save_to_memory` で記録（学習用）
-- 最大イテレーション回数: 3回（超えたら Owner に報告）
-
-### 品質チェックの合格条件
-
-- アプリが正常に起動・動作する
-- 明らかなバグがない
-- UI が期待通りに表示される（UI タスクの場合）
-- テストがパスする（テストがある場合）
-
-### Owner への完了報告（Admin が実行）
-
-品質チェックをパスしたら、Admin は Owner に完了を報告する。
-
-```
-mcp__multi-agent-mcp__send_message
-```
-
-- `to_agent_id`: Owner の ID
-- `content`: 完了報告（実行結果サマリー、各 Worker の状態、品質チェック結果）
-
-**報告内容の例**:
-
-```
-全タスク完了しました。
-
-## 実行結果
-- Worker 1: Task 1 ✅ 完了
-- Worker 2: Task 2 ✅ 完了
-
-## 品質チェック
-- アプリ起動: ✅ OK
-- テスト実行: ✅ パス
-- イテレーション回数: 1回
-
-Phase 5 に進んでください。
-```
-
----
-
-## Phase 5: 結果確認 + コミットメッセージ出力（Owner が実行）
+## Phase 5: 結果確認 + コミットメッセージ出力
 
 ### ステップ 0: Admin からの完了報告を確認
 
 ```
-mcp__multi-agent-mcp__read_messages
+mcp__multi-agent-mcp__read_messages()
 ```
-
-Admin から完了報告を受け取ったら Phase 5 を開始する。
 
 ### ステップ 1: 結果統合確認
 
@@ -281,11 +127,11 @@ git pull origin feature/{slug}
 ### ステップ 2: クリーンアップ
 
 ```
-mcp__multi-agent-mcp__check_all_tasks_completed
-mcp__multi-agent-mcp__cleanup_on_completion  # ターミナル自動終了
+mcp__multi-agent-mcp__check_all_tasks_completed()
+mcp__multi-agent-mcp__cleanup_on_completion()
 ```
 
-### ステップ 3: セキュリティチェック＆自己レビュー
+### ステップ 3: セキュリティチェック
 
 ```bash
 git status  # .env*, *.pem, credentials.json を検出したら警告
@@ -294,22 +140,7 @@ git diff main...feature/{slug}
 
 ### ステップ 4: ユーザー確認
 
-```
-## 変更内容の確認
-
-### 並列実行結果
-- Worker 1: {Task 1} ✅ 完了
-- Worker 2: {Task 2} ✅ 完了
-...
-
-### 変更サマリー
-{git diff --stat}
-
-### 推奨コミットメッセージ
-{自動生成されたメッセージ}
-
-この内容でよろしいですか？
-```
+変更内容、並列実行結果、推奨コミットメッセージを表示してユーザーに確認。
 
 ### ステップ 5: コミットメッセージ出力
 
@@ -317,10 +148,6 @@ git diff main...feature/{slug}
 
 ```
 ## 実装完了
-
-### 作成されたブランチ
-- ベース: feature/{slug}
-- 作業: feature/{slug}-1, feature/{slug}-2, ...
 
 ### 推奨コミットメッセージ
 {Conventional Commits 形式}
@@ -331,34 +158,3 @@ git diff main...feature/{slug}
 3. git push origin feature/{slug}
 4. 必要に応じて gh pr create
 ```
-
----
-
-## 重要な注意事項
-
-### Owner がやること
-
-- ✅ ブランチ作成
-- ✅ MCP ワークスペース初期化
-- ✅ tmux セッション作成
-- ✅ Owner/Admin エージェント作成
-- ✅ Admin に `send_task` で計画書送信
-- ✅ Admin の完了を待機
-- ✅ 結果確認・クリーンアップ
-- ✅ コミットメッセージ出力
-
-### Owner がやらないこと
-
-- ❌ Worker を直接作成（Admin の仕事）
-- ❌ タスク分割（Admin の仕事）
-- ❌ Worker にタスク直接送信（Admin の仕事）
-- ❌ Issue/PR 作成
-- ❌ 自動コミット・プッシュ
-- ❌ main ブランチで直接作業
-
-### MCP ツール使用ルール
-
-- MCP ツールは `mcp__multi-agent-mcp__*` 形式で呼び出し
-- Worker 数は最大 16
-- 各 Worker は git worktree で独立したディレクトリで作業
-- Dashboard でタスク進捗を管理

--- a/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
@@ -15,65 +15,31 @@ MCP マルチエージェントで Issue から PR まで並列実行する開�
 - multi-agent-mcp がインストール済み（**必須**）
 - tmux がインストール済み（**必須**）
 
-**確認方法**:
-
-```bash
-which tmux
-claude mcp list | grep multi-agent-mcp
-```
-
 ## 引数
 
 - `--plan`: plan mode で計画書を新規作成してから実行
 - `--workers N`: Worker 数を指定（省略時はプロファイル設定に従う）
 - `--profile standard|performance`: モデルプロファイル選択
-  - `standard`（デフォルト）: Sonnet、Worker 上限 6
-  - `performance`: Opus、Worker 上限 16（複雑なタスク向け）
 - `--help`: ヘルプを表示
 - `[タスク説明]`: 計画書なしで直接実行（簡単なタスク用）
 
-## アーキテクチャ
-
-```
-┌───────────────────────────────────────────────────────────────────┐
-│                    tmux セッション (main)                          │
-├─────────────────┬────────────┬────────────┬────────────┐
-│     pane 0      │   pane 1   │   pane 3   │   pane 5   │
-│     Admin       │    W1      │    W3      │    W5      │
-│     (40%)       ├────────────┼────────────┼────────────┤
-│ (タスク分割・   │   pane 2   │   pane 4   │   pane 6   │
-│  管理)          │    W2      │    W4      │    W6      │
-└─────────────────┴────────────┴────────────┴────────────┘
-     左40%              右60% (Workers 1-6, 3列×2行)
-```
-
-**役割分担**:
-
-| 役割   | 実行者                          | 責務                               |
-| ------ | ------------------------------- | ---------------------------------- |
-| Owner  | 起点 Claude Code（tmux なし）   | 全体指揮、Admin の管理、結果の確認 |
-| Admin  | tmux pane 0                     | タスク分割、Worker 管理、進捗監視  |
-| Worker | tmux pane 1-6+                  | タスク実行、worktree で作業        |
-
-## 3つの実行モード
-
-1. **計画書実行モード**（引数なし）: 既存の承認済み計画書から実行
-2. **計画書作成モード**（`--plan`）: plan mode で計画書を作成してから実行
-3. **直接実行モード**（タスク説明あり）: 計画書なしで直接実行
-
-## 実行フロー概要
+## 実行フロー
 
 ```
 Phase 1: Owner  → Issue 作成 → ブランチ作成 → MCP 初期化 → Admin 起動 → 計画書送信
-Phase 2: Admin  → タスク分割 → Worker 作成・管理（自律実行）
-Phase 3: Worker → タスク実行 → Admin に報告（自律実行）
-Phase 4: Admin  → 品質チェック → 問題あれば修正タスク作成 → Phase 2 に戻る（ループ）
+Phase 2-4: Admin/Worker が自律実行（MCP が自動制御）
 Phase 5: Owner  → 結果確認 → クリーンアップ → PR 作成 → Issue クローズ
+```
+
+## Owner の役割（MCP から取得）
+
+```
+mcp__multi-agent-mcp__get_role_guide(role="owner")
 ```
 
 ---
 
-## Phase 1: Issue 作成 + セットアップ + Admin 起動（Owner が実行）
+## Phase 1: Issue 作成 + セットアップ + Admin 起動
 
 ### ステップ 1: Issue 作成
 
@@ -111,187 +77,66 @@ git push -u origin feature/{issue番号}
 ### ステップ 3: MCP ワークスペース初期化
 
 ```
-mcp__multi-agent-mcp__init_workspace
+mcp__multi-agent-mcp__init_workspace(workspace_path="プロジェクト名")
 ```
-
-- `workspace_path`: プロジェクト名
 
 ### ステップ 4: tmux ワークスペース作成
 
 ```
-mcp__multi-agent-mcp__init_tmux_workspace
+mcp__multi-agent-mcp__init_tmux_workspace(
+    working_dir="プロジェクトのルートパス",
+    open_terminal=true,
+    auto_setup_gtr=true
+)
 ```
 
-- `working_dir`: プロジェクトのルートパス
-- `open_terminal`: true
-- `auto_setup_gtr`: true（gtr 自動設定）
-
-**自動作成**: `memory/`, `screenshot/` ディレクトリと `.env` テンプレートが自動生成されます。
-
-### ステップ 4.5: モデルプロファイル設定（`--profile` 指定時）
+### ステップ 4.5: モデルプロファイル設定（`--profile` 指定時のみ）
 
 ```
-mcp__multi-agent-mcp__switch_model_profile
+mcp__multi-agent-mcp__switch_model_profile(profile="standard" or "performance")
 ```
 
-- `profile`: "standard" または "performance"
-
-**注意**: `--profile performance` 指定時のみ実行。Worker 上限 16、Opus モデルに切替。
-
-### ステップ 5: Owner エージェント登録
+### ステップ 5: エージェント作成
 
 ```
-mcp__multi-agent-mcp__create_agent
+mcp__multi-agent-mcp__create_agent(role="owner", working_dir="パス")
+mcp__multi-agent-mcp__create_agent(role="admin", working_dir="パス")
 ```
 
-- `role`: "owner"
-- `working_dir`: プロジェクトのルートパス
-
-**注意**: Owner は tmux ペインなし。IPC 自動登録 + メトリクス記録開始。
-
-### ステップ 6: Admin エージェント作成
+### ステップ 6: Admin に計画書を送信
 
 ```
-mcp__multi-agent-mcp__create_agent
+mcp__multi-agent-mcp__send_task(
+    agent_id="Admin の ID",
+    task_content="計画書またはタスク説明",
+    session_id="Issue 番号",
+    worker_count=N,
+    branch_name="feature/{issue番号}"
+)
 ```
 
-- `role`: "admin"
-- `working_dir`: プロジェクトのルートパス
-
-**注意**: tmux pane 0 に配置。IPC 自動登録 + メトリクス記録開始。
-
-### ステップ 7: Admin に計画書を送信
+### ステップ 7: Admin の完了を待機
 
 ```
-mcp__multi-agent-mcp__send_task
-```
-
-- `agent_id`: Admin の ID
-- `task_content`: 計画書またはタスク説明
-- `session_id`: Issue 番号（例: "123"）
-- `worker_count`: Worker 数（省略時はプロファイル設定、`--workers` 指定時はその値）
-- `branch_name`: 作業ブランチ名（例: "feature/123"）
-
-**自動処理**: MCP が Admin 用の指示テンプレートを自動生成（Worker 管理手順、メモリ検索結果を含む）
-
-### ステップ 8: Admin の完了を待機
-
-Admin が自律的に Worker を作成・管理。Owner は完了報告を待つ。
-
-```
-mcp__multi-agent-mcp__get_dashboard_summary  # 進捗確認（軽量）
-mcp__multi-agent-mcp__read_messages          # Admin からのメッセージ確認
+mcp__multi-agent-mcp__get_dashboard_summary()
+mcp__multi-agent-mcp__read_messages()
 ```
 
 ---
 
-## Phase 2-3: Admin/Worker の自律実行
+## Phase 2-4: Admin/Worker の自律実行
 
-**Admin と Worker は自律的に動作します。Owner は実行しません。**
-
-### Admin の役割
-
-1. 計画書からサブタスクを抽出し Dashboard に登録
-2. スクリーンショット確認（UI タスクの場合、`read_latest_screenshot` で視覚的問題を分析）
-3. Worker 用 Worktree を作成
-4. Worker エージェントを作成・タスク送信
-5. 進捗を監視
-6. **品質チェック**: Worker 完了後に動作確認（アプリ実行、テスト実行）
-7. **イテレーション**: 問題があれば修正タスクを作成し Worker に再割り当て
-8. 品質チェックをパスしたら Owner に報告
-
-### Worker の役割
-
-1. 指示されたタスクを実装
-2. コミット・プッシュし、ベースブランチにマージ
-3. Admin に完了報告
-
-**MCP 自動処理**:
-
-- `send_task`: 7セクション構造、ペルソナ、メモリ検索を自動統合
-- `report_task_completion`: メモリ保存、メトリクス更新を自動実行
+**MCP が自動制御。Owner は待機のみ。**
 
 ---
 
-## Phase 4: 品質チェック・イテレーション（Admin が自律実行）
-
-### 品質チェックの流れ
-
-1. **動作確認**: Worker 完了後、アプリを実行してテスト
-
-   ```bash
-   git pull origin {branch_name}
-   npm start  # または python main.py など
-   ```
-
-2. **UI 確認**（UI タスクの場合）:
-   - `read_latest_screenshot` で視覚的確認
-   - 期待通りの表示か確認
-
-3. **問題発見時**: 修正タスクを作成してイテレーション
-
-   ```
-   while (品質に問題あり):
-       1. 問題を分析・リスト化
-       2. create_task で修正タスク登録
-       3. Worker に send_task で修正依頼
-       4. Worker 完了を待機
-       5. 再度品質チェック
-   ```
-
-### イテレーションのルール
-
-- 1回のイテレーションで1-2個の問題に絞る
-- 同じ問題が3回以上繰り返される場合は Owner に相談
-- 修正内容は `save_to_memory` で記録（学習用）
-- 最大イテレーション回数: 3回（超えたら Owner に報告）
-
-### 品質チェックの合格条件
-
-- アプリが正常に起動・動作する
-- 明らかなバグがない
-- UI が期待通りに表示される（UI タスクの場合）
-- テストがパスする（テストがある場合）
-
-### Owner への完了報告（Admin が実行）
-
-品質チェックをパスしたら、Admin は Owner に完了を報告する。
-
-```
-mcp__multi-agent-mcp__send_message
-```
-
-- `to_agent_id`: Owner の ID
-- `content`: 完了報告（実行結果サマリー、各 Worker の状態、品質チェック結果）
-
-**報告内容の例**:
-
-```
-全タスク完了しました。
-
-## 実行結果
-- Worker 1: Task 1 ✅ 完了
-- Worker 2: Task 2 ✅ 完了
-
-## 品質チェック
-- アプリ起動: ✅ OK
-- テスト実行: ✅ パス
-- イテレーション回数: 1回
-
-Phase 5 に進んでください。
-```
-
----
-
-## Phase 5: 結果確認 + PR 作成（Owner が実行）
+## Phase 5: 結果確認 + PR 作成
 
 ### ステップ 0: Admin からの完了報告を確認
 
 ```
-mcp__multi-agent-mcp__read_messages
+mcp__multi-agent-mcp__read_messages()
 ```
-
-Admin から完了報告を受け取ったら Phase 5 を開始する。
 
 ### ステップ 1: 結果統合確認
 
@@ -303,11 +148,11 @@ git pull origin feature/{issue番号}
 ### ステップ 2: クリーンアップ
 
 ```
-mcp__multi-agent-mcp__check_all_tasks_completed
-mcp__multi-agent-mcp__cleanup_on_completion  # ターミナル自動終了
+mcp__multi-agent-mcp__check_all_tasks_completed()
+mcp__multi-agent-mcp__cleanup_on_completion()
 ```
 
-### ステップ 3: セキュリティチェック＆自己レビュー
+### ステップ 3: セキュリティチェック
 
 ```bash
 git status  # .env*, *.pem, credentials.json を検出したら警告
@@ -316,22 +161,7 @@ git diff main...feature/{issue番号}
 
 ### ステップ 4: ユーザー確認
 
-```
-## 変更内容の確認
-
-### 並列実行結果
-- Worker 1: {Task 1} ✅ 完了
-- Worker 2: {Task 2} ✅ 完了
-...
-
-### 変更サマリー
-{git diff --stat}
-
-### コミットメッセージ
-{自動生成されたメッセージ}
-
-この内容でコミット・プッシュ・PR作成を実行してよろしいですか？
-```
+変更内容、並列実行結果、コミットメッセージを表示してユーザーに確認。
 
 ### ステップ 5: Issue チェックボックス更新
 
@@ -361,7 +191,6 @@ gh pr create --title "{PRタイトル}" --body "{PR本文}"
 | Worker | Task | 状態 |
 |--------|------|------|
 | Worker 1 | Task 1 | ✅ 完了 |
-| Worker 2 | Task 2 | ✅ 完了 |
 ...
 
 ## 関連 Issue
@@ -385,34 +214,3 @@ Closes #{issue番号}
 
 PR がマージされると Issue #{issue番号} は自動的にクローズされます。
 ```
-
----
-
-## 重要な注意事項
-
-### Owner がやること
-
-- ✅ Issue 作成
-- ✅ ブランチ作成
-- ✅ MCP ワークスペース初期化
-- ✅ tmux セッション作成
-- ✅ Owner/Admin エージェント作成
-- ✅ Admin に `send_task` で計画書送信
-- ✅ Admin の完了を待機
-- ✅ 結果確認・クリーンアップ
-- ✅ PR 作成
-
-### Owner がやらないこと
-
-- ❌ Worker を直接作成（Admin の仕事）
-- ❌ タスク分割（Admin の仕事）
-- ❌ Worker にタスク直接送信（Admin の仕事）
-- ❌ ユーザー確認なしでコミット・プッシュ
-- ❌ main ブランチで直接作業
-
-### MCP ツール使用ルール
-
-- MCP ツールは `mcp__multi-agent-mcp__*` 形式で呼び出し
-- Worker 数は最大 16
-- 各 Worker は git worktree で独立したディレクトリで作業
-- Dashboard でタスク進捗を管理


### PR DESCRIPTION
## 概要

- multi-flow/SKILL.md のスリム化（365行 → 約160行）
- multi-issue-flow/SKILL.md のスリム化（419行 → 約217行）
- MCP から Owner の振る舞いを取得するよう変更
- バージョンを 1.6.0 に更新

## 変更の背景

SKILL.md が肥大化しており、MCP側で既に自動化されている内容と重複していた。
責務を明確に分離：
- **MCP側**: マルチエージェントの振る舞い制御（Owner/Admin/Worker ロール）
- **SKILL.md**: ワークフロー固有の手順（git コマンド、Issue/PR 作成）

## 関連 Issue

Closes #107

## テスト計画

- [ ] `/multi-flow` を実行して MCP が正しく動作すること
- [ ] `/multi-issue-flow` を実行して MCP が正しく動作すること