### PR TITLE
fix(workflow): Phase 5 の変更確認手順を統一

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ pip install -r requirements.txt
 | [`shiiman-plugin`](plugins/shiiman-plugin/) | プラグイン管理用プラグイン - 一覧表示、詳細表示、インストール、アンインストール、有効化、無効化、アップデート機能を提供 | `/plugin install shiiman-plugin@shiiman-claude-code-plugins` |
 | [`shiiman-claude`](plugins/shiiman-claude/) | Claude Code プロジェクト設定管理プラグイン - スキル/エージェント/フックの追加、設定更新、ドキュメント更新、モデル切り替え、コンテキスト管理機能を提供 | `/plugin install shiiman-claude@shiiman-claude-code-plugins` |
 | [`shiiman-git`](plugins/shiiman-git/) | Git/GitHub ワークフロー管理 - セットアップ、コミット、Issue、PR、Actions 管理機能を提供 | `/plugin install shiiman-git@shiiman-claude-code-plugins` |
-| [`shiiman-workflow`](plugins/shiiman-workflow/) | 開発ワークフロー自動化 - シングル/マルチエージェントでの Issue 管理付き・なしのフローを提供 | `/plugin install shiiman-workflow@shiiman-claude-code-plugins` |
+| [`shiiman-workflow`](plugins/shiiman-workflow/) | 開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供 | `/plugin install shiiman-workflow@shiiman-claude-code-plugins` |
 | [`shiiman-google`](plugins/shiiman-google/) | Google Workspace 操作 - 認証、Drive/Docs/Sheets/Slides/Forms/Apps Script、Calendar、Gmail 機能を提供 | `/plugin install shiiman-google@shiiman-claude-code-plugins` |
 | [`shiiman-go`](plugins/shiiman-go/) | Go 言語開発支援 - フォーマット、静的解析、テスト、依存関係管理、ビルド、パフォーマンス計測、脆弱性スキャン | `/plugin install shiiman-go@shiiman-claude-code-plugins` |
 | [`shiiman-docker`](plugins/shiiman-docker/) | Docker/Docker Compose 管理 - コンテナ、イメージ、ネットワーク、ボリューム、Dockerfile の操作を支援 | `/plugin install shiiman-docker@shiiman-claude-code-plugins` |
 | [`shiiman-terraform`](plugins/shiiman-terraform/) | Terraform/Terragrunt 管理 - コマンド実行、バージョン管理、モジュール管理、state 操作、import 支援、セキュリティ監査 | `/plugin install shiiman-terraform@shiiman-claude-code-plugins` |
-| [`shiiman-slack`](plugins/shiiman-slack/) | Slack ワークスペース管理 - MCP サーバーによるチャンネル操作、メッセージ管理、要約機能を提供 | `/plugin install shiiman-slack@shiiman-claude-code-plugins` |
+| [`shiiman-slack`](plugins/shiiman-slack/) | Slack ワークスペース管理 - チャンネル操作、メッセージ管理、要約機能、User Token によるユーザー操作を提供 | `/plugin install shiiman-slack@shiiman-claude-code-plugins` |
 
 **インストール例**:
 
@@ -102,9 +102,14 @@ pip install -r requirements.txt
 | コマンド | 説明 |
 |----------|------|
 | `/plugin-create` | 新しいプラグインを作成 |
+| `/plugin-create-full` | スキル/サブエージェント/フックを含むプラグインを一括作成 |
 | `/skill-create` | プラグインにスキルを追加 |
 | `/subagent-create` | プラグインにサブエージェントを追加 |
 | `/hook-create` | プラグインにフックを追加 |
+| `/issue-create` | 計画から GitHub Issue を作成 |
+| `/pr-create` | PR を作成し関連 Issue をクローズ |
+| `/pr-review-check` | PR のレビューコメントを確認して修正対応 |
+| `/multi-agent-test` | MCP マルチエージェント環境検証と Admin 起動を実行 |
 
 ## 利用可能なスキル
 
@@ -136,6 +141,8 @@ pip install -r requirements.txt
 | multi-issue-flow | shiiman-workflow | 「マルチ Issue フロー」「並列 Issue 開発」 | MCP マルチエージェントで Issue から PR まで並列実行 |
 | single-flow | shiiman-workflow | 「シングルフロー」「軽量フロー」 | Issue/PR なしで計画書からタスク実行する軽量フロー |
 | multi-flow | shiiman-workflow | 「マルチフロー」「並列軽量フロー」 | MCP マルチエージェントで Issue/PR なしに並列実行する軽量フロー |
+| agent-team-issue-flow | shiiman-workflow | 「agent-team-issue-flow」「Agent Team Issue」 | Agent Team で Issue から PR まで並列実行 |
+| agent-team-flow | shiiman-workflow | 「agent-team-flow」「エージェントチームフロー」 | Agent Team で Issue/PR なしに並列実行する軽量フロー |
 
 ### 開発支援
 

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/README.md
+++ b/plugins/shiiman-workflow/README.md
@@ -171,6 +171,7 @@ Agent Team で Issue/PR なしに並列実行する軽量フロー。
 
 ## バージョン履歴
 
+- v1.7.4: Phase 5 の変更確認手順を統一（`git status --short --branch` + `git diff` + `git diff --cached`）
 - v1.7.1: agent-team-flow / agent-team-issue-flow を仕様準拠に修正（Ghostty/iTerm2 + tmux + Agent Team 実行フローへ統一）
 - v1.5.0: SKILL.md を約 60% スリム化。MCP 側で Admin/Worker 指示を自動生成
 - v1.4.0: Worker 数をデフォルト 6、最大 16 に変更。MCP 自動機能（ペルソナ、メモリ、7セクション構造）を統合

--- a/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
@@ -114,6 +114,8 @@ Agent Team が計画書を分解して実装を進める。呼び出し元は待
 
 ```bash
 git status --short --branch
+git diff
+git diff --cached
 ```
 
 ### ステップ 2: ユーザー承認を取得（必須）

--- a/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
@@ -137,6 +137,8 @@ Agent Team が計画書を分解して実装を進める。呼び出し元は待
 
 ```bash
 git status --short --branch
+git diff
+git diff --cached
 ```
 
 ### ステップ 2: ユーザー承認を取得（必須）

--- a/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
@@ -144,23 +144,17 @@ mcp__multi-agent-mcp__read_messages(
 )
 ```
 
-### ステップ 1: 結果統合確認
+### ステップ 1: 変更内容をユーザーに表示
 
 ```bash
-git checkout feature/{slug}
-git pull origin feature/{slug}
-```
-
-### ステップ 2: 変更内容をユーザーに表示
-
-```bash
-git diff main...feature/{slug} --stat
-git log main..feature/{slug} --oneline
+git status --short --branch
+git diff
+git diff --cached
 ```
 
 変更内容、品質チェック結果（Admin からの報告）をユーザーに表示。
 
-### ステップ 3: ユーザー確認（🔴 必須）
+### ステップ 2: ユーザー確認（🔴 必須）
 
 **⚠️ クリーンアップの前に必ずユーザー確認を行う**
 
@@ -182,7 +176,7 @@ AskUserQuestion:
 
 ### OK（承認）の場合
 
-#### ステップ 4: Admin に承認通知を送信
+#### ステップ 3: Admin に承認通知を送信
 
 ```
 mcp__multi-agent-mcp__send_message(
@@ -215,20 +209,20 @@ mcp__multi-agent-mcp__send_message(
 
 ---
 
-#### ステップ 5: クリーンアップ
+#### ステップ 4: クリーンアップ
 
 ```
 mcp__multi-agent-mcp__check_all_tasks_completed(caller_agent_id="{owner_id}")
 mcp__multi-agent-mcp__cleanup_on_completion(caller_agent_id="{owner_id}")
 ```
 
-#### ステップ 6: セキュリティチェック
+#### ステップ 5: セキュリティチェック
 
 ```bash
 git status  # .env*, *.pem, credentials.json を検出したら警告
 ```
 
-#### ステップ 7: コミットメッセージ出力
+#### ステップ 6: コミットメッセージ出力
 
 **重要: このフローではコミット・プッシュ・PR作成を行いません。**
 

--- a/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
@@ -165,23 +165,17 @@ mcp__multi-agent-mcp__read_messages(
 )
 ```
 
-### ステップ 1: 結果統合確認
+### ステップ 1: 変更内容をユーザーに表示
 
 ```bash
-git checkout feature/{issue番号}
-git pull origin feature/{issue番号}
-```
-
-### ステップ 2: 変更内容をユーザーに表示
-
-```bash
-git diff main...feature/{issue番号} --stat
-git log main..feature/{issue番号} --oneline
+git status --short --branch
+git diff
+git diff --cached
 ```
 
 変更内容、品質チェック結果（Admin からの報告）をユーザーに表示。
 
-### ステップ 3: ユーザー確認（🔴 必須）
+### ステップ 2: ユーザー確認（🔴 必須）
 
 **⚠️ クリーンアップの前に必ずユーザー確認を行う**
 
@@ -203,7 +197,7 @@ AskUserQuestion:
 
 ### OK（承認）の場合
 
-#### ステップ 4: Admin に承認通知を送信
+#### ステップ 3: Admin に承認通知を送信
 
 ```
 mcp__multi-agent-mcp__send_message(
@@ -236,24 +230,24 @@ mcp__multi-agent-mcp__send_message(
 
 ---
 
-#### ステップ 5: クリーンアップ
+#### ステップ 4: クリーンアップ
 
 ```
 mcp__multi-agent-mcp__check_all_tasks_completed(caller_agent_id="{owner_id}")
 mcp__multi-agent-mcp__cleanup_on_completion(caller_agent_id="{owner_id}")
 ```
 
-#### ステップ 6: セキュリティチェック
+#### ステップ 5: セキュリティチェック
 
 ```bash
 git status  # .env*, *.pem, credentials.json を検出したら警告
 ```
 
-#### ステップ 7: Issue チェックボックス更新
+#### ステップ 6: Issue チェックボックス更新
 
 Issue の全てのチェックボックスを完了状態に更新。
 
-#### ステップ 8: コミット・プッシュ
+#### ステップ 7: コミット・プッシュ
 
 ```bash
 git add .
@@ -261,7 +255,7 @@ git commit -m "{コミットメッセージ}"
 git push origin feature/{issue番号}
 ```
 
-#### ステップ 9: PR 作成
+#### ステップ 8: PR 作成
 
 ```bash
 gh pr create --title "{PRタイトル}" --body "{PR本文}"
@@ -286,7 +280,7 @@ Closes #{issue番号}
 - [ ] {テスト項目}
 ```
 
-#### ステップ 10: 完了報告
+#### ステップ 9: 完了報告
 
 ```
 ## 開発フロー完了


### PR DESCRIPTION
## 概要
workflow 系スキルの Phase 5 における変更確認手順を `git status --short --branch` + `git diff` + `git diff --cached` に統一しました。
併せて `shiiman-workflow` のバージョンを更新し、README 記載を現状に同期しました。

## 変更内容
- `agent-team-flow` / `agent-team-issue-flow` の変更確認手順を統一
- `multi-flow` / `multi-issue-flow` から結果統合確認ステップを削除し、変更確認手順を統一
- `multi-flow` / `multi-issue-flow` の手順番号を繰り上げ調整
- `shiiman-workflow` バージョンを `1.7.4` に更新
- `.claude-plugin/marketplace.json` の `shiiman-workflow` バージョンを `1.7.4` に更新
- `plugins/shiiman-workflow/README.md` のバージョン履歴を更新
- ルート `README.md` のコマンド/スキル一覧と説明を現状に同期

## テスト
- `pytest -q tests/test_plugin_json.py`（71 passed）

Closes #111
