### PR TITLE
fix: Agent Team のターミナル起動仕様と文字化け問題を修正

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/README.md
+++ b/plugins/shiiman-workflow/README.md
@@ -123,14 +123,15 @@ Agent Team で Issue から PR まで並列実行する開発フロー。
 **フロー**:
 
 ```text
-計画書 → Issue → ブランチ → Ghostty/iTerm2 + tmux 起動 → Agent Team 実装 → レビュー → コミット → PR
+計画書 → Issue → ブランチ → ターミナル + tmux 起動 → Agent Team 実装 → レビュー → コミット → PR
 ```
 
 **特徴**:
 
 - `multi-issue-flow` の MCP 使用部分を Agent Team 実行に置き換え
 - `claude --dangerously-skip-permissions` で Agent Team 実行
-- Ghostty 優先、未導入時は iTerm2 で tmux セッションを起動
+- ターミナル起動は `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を使用（既存起動時は新規タブ、未起動時は新規ウィンドウ先頭タブ）
+- ターミナル選択順は `ghostty -> iterm2 -> Terminal.app -> current shell`
 - 2 つの Agent Team スキルで共通利用する送信スクリプトは `plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh` を使用
 
 ### agent-team-flow
@@ -142,8 +143,8 @@ Agent Team で Issue/PR なしに並列実行する軽量フロー。
 **フロー**:
 
 ```text
-git モード: 計画書 → ブランチ → Ghostty/iTerm2 + tmux 起動 → Agent Team 実装 → レビュー → コミットメッセージ出力
-no-git モード: 計画書 → Ghostty/iTerm2 + tmux 起動 → Agent Team 実装 → レビュー
+git モード: 計画書 → ブランチ → ターミナル + tmux 起動 → Agent Team 実装 → レビュー → コミットメッセージ出力
+no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実装 → レビュー
 ```
 
 **特徴**:
@@ -153,6 +154,8 @@ no-git モード: 計画書 → Ghostty/iTerm2 + tmux 起動 → Agent Team 実�
 - `--no-git` 指定時、または `git rev-parse --is-inside-work-tree` 失敗時は no-git モードへ切替
 - no-git モードではブランチ作成と push 前提手順を行わない
 - 問題時は Agent Team に再指示してループ可能
+- ターミナル起動は `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を使用（既存起動時は新規タブ、未起動時は新規ウィンドウ先頭タブ）
+- ターミナル選択順は `ghostty -> iterm2 -> Terminal.app -> current shell`
 - 2 つの Agent Team スキルで共通利用する送信スクリプトは `plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh` を使用
 
 ## 必要条件
@@ -173,10 +176,11 @@ no-git モード: 計画書 → Ghostty/iTerm2 + tmux 起動 → Agent Team 実�
 - `CLAUDE_PLUGIN_ROOT` が利用可能なプラグイン実行コンテキストで実行
 - `claude` コマンドが利用可能
 - tmux がインストール済み
-- macOS で Ghostty または iTerm2 が利用可能
+- macOS で Ghostty または iTerm2 を推奨（未導入時は Terminal.app / 現在端末にフォールバック）
 
 ## バージョン履歴
 
+- v1.8.1: `agent-team-flow` / `agent-team-issue-flow` のターミナル起動を共通化し、既存起動時の新規タブ化と文字化け対策を修正
 - v1.8.0: `multi-flow` / `agent-team-flow` に `--no-git` と git/no-git 自動分岐を追加（非gitディレクトリ対応）
 - v1.7.4: Phase 5 の変更確認手順を統一（`git status --short --branch` + `git diff` + `git diff --cached`）
 - v1.7.1: agent-team-flow / agent-team-issue-flow を仕様準拠に修正（Ghostty/iTerm2 + tmux + Agent Team 実行フローへ統一）

--- a/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
+++ b/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  open_tmux_terminal.sh --session <name> --repo-root <path> [--terminal <auto|ghostty|iterm2|terminal>] [--dry-run]
+
+Options:
+  --session <name>      tmux session name (allowed: [A-Za-z0-9._:-])
+  --repo-root <path>    repository root path
+  --terminal <value>    auto | ghostty | iterm2 | terminal (default: auto)
+  --dry-run             print selected behavior without opening terminals
+  -h, --help            show this help
+USAGE
+}
+
+SESSION=""
+REPO_ROOT=""
+TERMINAL="auto"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session)
+      SESSION="${2:-}"
+      shift 2
+      ;;
+    --repo-root)
+      REPO_ROOT="${2:-}"
+      shift 2
+      ;;
+    --terminal)
+      TERMINAL="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$SESSION" || -z "$REPO_ROOT" ]]; then
+  echo "--session and --repo-root are required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! "$SESSION" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+  echo "invalid session name: $SESSION" >&2
+  exit 2
+fi
+
+if [[ ! -d "$REPO_ROOT" ]]; then
+  echo "repo root is not a directory: $REPO_ROOT" >&2
+  exit 2
+fi
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+
+case "$TERMINAL" in
+  auto|ghostty|iterm2|terminal)
+    ;;
+  *)
+    echo "invalid --terminal value: $TERMINAL" >&2
+    exit 2
+    ;;
+esac
+
+printf -v TMUX_CMD 'tmux new-session -A -s %q -c %q' "$SESSION" "$REPO_ROOT"
+
+escape_applescript() {
+  local value="${1:-}"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
+}
+
+is_ghostty_available() {
+  [[ -d "/Applications/Ghostty.app" ]] || command -v ghostty >/dev/null 2>&1
+}
+
+is_iterm2_available() {
+  osascript -e 'application "iTerm" exists' >/dev/null 2>&1
+}
+
+is_ghostty_running() {
+  local stdout
+  if stdout="$(osascript -e 'if application "Ghostty" is running then return "true" else return "false" end if' 2>/dev/null)"; then
+    [[ "$stdout" == "true" ]]
+    return
+  fi
+  pgrep -x Ghostty >/dev/null 2>&1 || pgrep -x ghostty >/dev/null 2>&1
+}
+
+open_in_running_ghostty_tab() {
+  local escaped_cmd
+  escaped_cmd="$(escape_applescript "$TMUX_CMD")"
+  local applescript
+  applescript=$(cat <<EOF
+set the clipboard to "$escaped_cmd"
+tell application "Ghostty"
+    activate
+end tell
+tell application "System Events"
+    if exists process "Ghostty" then
+        tell process "Ghostty"
+            keystroke "t" using command down
+            delay 0.5
+            keystroke "v" using command down
+            delay 0.1
+            keystroke return
+        end tell
+    else if exists process "ghostty" then
+        tell process "ghostty"
+            keystroke "t" using command down
+            delay 0.5
+            keystroke "v" using command down
+            delay 0.1
+            keystroke return
+        end tell
+    else
+        error "Ghostty process not found"
+    end if
+end tell
+EOF
+)
+  osascript -e "$applescript" >/dev/null 2>&1
+}
+
+open_in_ghostty() {
+  if ! is_ghostty_available; then
+    return 1
+  fi
+
+  if is_ghostty_running; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY-RUN] Ghostty is running: open new tab and run: $TMUX_CMD"
+      return 0
+    fi
+    if open_in_running_ghostty_tab; then
+      echo "Opened tmux in a new Ghostty tab."
+      return 0
+    fi
+    echo "Ghostty tab open failed, falling back to new window." >&2
+  fi
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] Ghostty is not running: open new window first tab and run: $TMUX_CMD"
+    return 0
+  fi
+
+  if ! open -a Ghostty.app --args -e /bin/bash -lc "$TMUX_CMD" >/dev/null 2>&1; then
+    return 1
+  fi
+  echo "Opened tmux in a new Ghostty window."
+  return 0
+}
+
+open_in_iterm2() {
+  if ! is_iterm2_available; then
+    return 1
+  fi
+
+  local escaped_cmd
+  escaped_cmd="$(escape_applescript "$TMUX_CMD")"
+  local applescript
+  applescript=$(cat <<EOF
+tell application "iTerm"
+    activate
+    if (count of windows) > 0 then
+        tell current window
+            create tab with default profile
+            tell current session
+                write text "$escaped_cmd"
+            end tell
+        end tell
+    else
+        create window with default profile
+        tell current session of current window
+            write text "$escaped_cmd"
+        end tell
+    end if
+end tell
+EOF
+)
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] iTerm2: existing window -> new tab, otherwise new window first tab. Command: $TMUX_CMD"
+    return 0
+  fi
+
+  if ! osascript -e "$applescript" >/dev/null 2>&1; then
+    return 1
+  fi
+  echo "Opened tmux in iTerm2."
+  return 0
+}
+
+open_in_terminal_app() {
+  local escaped_cmd
+  escaped_cmd="$(escape_applescript "$TMUX_CMD")"
+  local applescript
+  applescript=$(cat <<EOF
+tell application "Terminal"
+    activate
+    if (count of windows) > 0 then
+        tell front window
+            do script "$escaped_cmd"
+        end tell
+    else
+        do script "$escaped_cmd"
+    end if
+end tell
+EOF
+)
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] Terminal.app: existing window -> new tab, otherwise new window first tab. Command: $TMUX_CMD"
+    return 0
+  fi
+
+  if ! osascript -e "$applescript" >/dev/null 2>&1; then
+    return 1
+  fi
+  echo "Opened tmux in Terminal.app."
+  return 0
+}
+
+open_in_current_shell() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] Current shell fallback: $TMUX_CMD"
+    return 0
+  fi
+  tmux new-session -A -s "$SESSION" -c "$REPO_ROOT"
+}
+
+case "$TERMINAL" in
+  ghostty)
+    if ! open_in_ghostty; then
+      echo "failed to open in Ghostty" >&2
+      exit 1
+    fi
+    ;;
+  iterm2)
+    if ! open_in_iterm2; then
+      echo "failed to open in iTerm2" >&2
+      exit 1
+    fi
+    ;;
+  terminal)
+    if ! open_in_terminal_app; then
+      echo "failed to open in Terminal.app" >&2
+      exit 1
+    fi
+    ;;
+  auto)
+    if open_in_ghostty; then
+      exit 0
+    fi
+    if open_in_iterm2; then
+      exit 0
+    fi
+    if open_in_terminal_app; then
+      exit 0
+    fi
+    echo "Ghostty/iTerm2/Terminal.app unavailable. Falling back to current shell."
+    open_in_current_shell
+    ;;
+esac

--- a/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
@@ -16,7 +16,7 @@ Agent Team で Issue/PR なしに並列実装を進める軽量フロー。
 - `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` が設定済み（必須）
 - `claude` コマンドが利用可能
 - `tmux` が利用可能
-- macOS で `Ghostty` または `iTerm2` が利用可能（Ghostty 優先）
+- macOS で `Ghostty` または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
 
 ## 引数
 
@@ -49,12 +49,12 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1
 
 ```text
 git モード:
-Phase 1: ブランチ作成 → Ghostty/iTerm2 + tmux 起動 → claude 起動 → 計画書送信
+Phase 1: ブランチ作成 → ターミナル + tmux 起動 → claude 起動 → 計画書送信
 Phase 2-4: Agent Team が計画書を読み取り自律実装
 Phase 5: 結果確認 → 承認/修正依頼 → クリーンアップ → コミットメッセージ出力
 
 no-git モード:
-Phase 1: Ghostty/iTerm2 + tmux 起動 → claude 起動 → 計画書送信
+Phase 1: ターミナル + tmux 起動 → claude 起動 → 計画書送信
 Phase 2-4: Agent Team が計画書を読み取り自律実装
 Phase 5: 結果確認（Agent Team 報告）→ 承認/修正依頼 → クリーンアップ
 ```
@@ -91,21 +91,14 @@ git checkout -b feature/{slug}
 
 no-git モードではこのステップをスキップする。
 
-### ステップ 4: Ghostty (なければ iTerm2) を起動して tmux セッションを用意
+### ステップ 4: 共通スクリプトで tmux セッションを起動
 
 ```bash
 SESSION="agent-team-{slug}"
 REPO_ROOT="$(pwd)"
+OPEN_TMUX_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/open_tmux_terminal.sh"
 
-if [ -d "/Applications/Ghostty.app" ]; then
-  open -na Ghostty
-  echo "Ghostty を起動。新しいウィンドウで: cd \"$REPO_ROOT\" && tmux new -As \"$SESSION\""
-elif [ -d "/Applications/iTerm.app" ]; then
-  open -na iTerm
-  echo "iTerm2 を起動。新しいウィンドウで: cd \"$REPO_ROOT\" && tmux new -As \"$SESSION\""
-else
-  echo "Ghostty/iTerm2 が見つからないため、現在の端末で: cd \"$REPO_ROOT\" && tmux new -As \"$SESSION\""
-fi
+bash "$OPEN_TMUX_SCRIPT" --session "$SESSION" --repo-root "$REPO_ROOT" --terminal auto
 ```
 
 ### ステップ 5: tmux 内で Claude Code を起動
@@ -305,5 +298,4 @@ rm -f "$HOLD_FILE"
 
 - `claude` 未インストール: インストール後に再実行
 - `tmux` 未インストール: `tmux` 導入後に再実行
-- Ghostty/iTerm2 なし: 現在のターミナルで tmux を起動して継続
 - Agent Team 側で部分失敗: 失敗タスクのみを再指示してループ

--- a/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
@@ -17,7 +17,7 @@ Agent Team で Issue 作成から PR 作成までを並列実行するフロー�
 - `claude` コマンドが利用可能
 - `tmux` が利用可能
 - `gh auth status` が成功する（GitHub CLI 認証済み）
-- macOS で `Ghostty` または `iTerm2` が利用可能（Ghostty 優先）
+- macOS で `Ghostty` または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
 
 ## 引数
 
@@ -28,7 +28,7 @@ Agent Team で Issue 作成から PR 作成までを並列実行するフロー�
 ## 実行フロー
 
 ```text
-Phase 1: Issue 作成 → ブランチ作成 → Ghostty/iTerm2 + tmux 起動 → claude 起動 → 計画書送信
+Phase 1: Issue 作成 → ブランチ作成 → ターミナル + tmux 起動 → claude 起動 → 計画書送信
 Phase 2-4: Agent Team が計画書を読み取り自律実装
 Phase 5: 結果確認 → 承認/修正依頼 → クリーンアップ → Issue 更新 → コミット/Push → PR 作成
 ```
@@ -66,21 +66,14 @@ git pull origin main
 git checkout -b feature/{issue_number}
 ```
 
-### ステップ 3: Ghostty (なければ iTerm2) を起動して tmux セッションを用意
+### ステップ 3: 共通スクリプトで tmux セッションを起動
 
 ```bash
 SESSION="agent-team-issue-{issue_number}"
 REPO_ROOT="$(pwd)"
+OPEN_TMUX_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/open_tmux_terminal.sh"
 
-if [ -d "/Applications/Ghostty.app" ]; then
-  open -na Ghostty
-  echo "Ghostty を起動。新しいウィンドウで: cd \"$REPO_ROOT\" && tmux new -As \"$SESSION\""
-elif [ -d "/Applications/iTerm.app" ]; then
-  open -na iTerm
-  echo "iTerm2 を起動。新しいウィンドウで: cd \"$REPO_ROOT\" && tmux new -As \"$SESSION\""
-else
-  echo "Ghostty/iTerm2 が見つからないため、現在の端末で: cd \"$REPO_ROOT\" && tmux new -As \"$SESSION\""
-fi
+bash "$OPEN_TMUX_SCRIPT" --session "$SESSION" --repo-root "$REPO_ROOT" --terminal auto
 ```
 
 ### ステップ 4: tmux 内で Claude Code を起動
@@ -267,5 +260,4 @@ rm -f "$HOLD_FILE"
 - `gh` 認証失敗: `gh auth login` 実施後に再開
 - `claude` 未インストール: インストール後に再実行
 - `tmux` 未インストール: `tmux` 導入後に再実行
-- Ghostty/iTerm2 なし: 現在のターミナルで tmux を起動して継続
 - Agent Team 側で部分失敗: 失敗タスクのみを再指示してループ

--- a/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-flow/SKILL.md
@@ -101,7 +101,6 @@ git fetch origin main
 git checkout main
 git pull origin main
 git checkout -b feature/{slug}
-git push -u origin feature/{slug}
 ```
 
 no-git モードではこのステップをスキップする。

--- a/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/multi-issue-flow/SKILL.md
@@ -78,7 +78,6 @@ git fetch origin main
 git checkout main
 git pull origin main
 git checkout -b feature/{issue番号}
-git push -u origin feature/{issue番号}
 ```
 
 ### ステップ 3: Owner エージェント作成


### PR DESCRIPTION
## 概要

Agent Team 系スキルのターミナル起動処理を共通化し、既存起動時の新規タブ化と日本語IME環境での文字化け問題を修正しました。

## 変更内容

- `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を追加
- `agent-team-flow` / `agent-team-issue-flow` の tmux 起動手順を共通スクリプト呼び出しへ置換
- Ghostty/iTerm2/Terminal.app の起動フォールバック順を統一（`ghostty -> iterm2 -> terminal -> current shell`）
- README とバージョン情報（`plugin.json`, `marketplace.json`）を `1.8.1` に更新
- 関連する `multi-flow` / `multi-issue-flow` の差分を取り込み

## 関連 Issue

Closes #115

## テスト計画

- [x] `bash -n plugins/shiiman-workflow/scripts/open_tmux_terminal.sh`
- [x] `pytest -q tests/test_plugin_json.py`
- [x] `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh --session test-session --repo-root /Users/a12665/Documents/personal/claude-code-plugins --terminal auto --dry-run`

## チェックリスト

- [x] 命名規則に従っている
- [x] README.md を更新した
- [x] 動作確認済み
