### PR TITLE
fix: Ghostty起動失敗とtmux target不整合を修正

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/README.md
+++ b/plugins/shiiman-workflow/README.md
@@ -132,6 +132,7 @@ Agent Team で Issue から PR まで並列実行する開発フロー。
 - `claude --dangerously-skip-permissions` で Agent Team 実行
 - ターミナル起動は `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を使用（既存起動時は新規タブ、未起動時は新規ウィンドウ先頭タブ）
 - ターミナル選択順は `ghostty -> iterm2 -> Terminal.app -> current shell`
+- tmux メッセージ送信先 target は固定値ではなく tmux 実値から動的解決
 - 2 つの Agent Team スキルで共通利用する送信スクリプトは `plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh` を使用
 
 ### agent-team-flow
@@ -156,6 +157,7 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 - 問題時は Agent Team に再指示してループ可能
 - ターミナル起動は `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を使用（既存起動時は新規タブ、未起動時は新規ウィンドウ先頭タブ）
 - ターミナル選択順は `ghostty -> iterm2 -> Terminal.app -> current shell`
+- tmux メッセージ送信先 target は固定値ではなく tmux 実値から動的解決
 - 2 つの Agent Team スキルで共通利用する送信スクリプトは `plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh` を使用
 
 ## 必要条件
@@ -180,6 +182,7 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 
 ## バージョン履歴
 
+- v1.8.2: Ghostty 起動フォールバックと tmux target 解決を修正（`0.0` 固定を廃止し実値解決へ変更）
 - v1.8.1: `agent-team-flow` / `agent-team-issue-flow` のターミナル起動を共通化し、既存起動時の新規タブ化と文字化け対策を修正
 - v1.8.0: `multi-flow` / `agent-team-flow` に `--no-git` と git/no-git 自動分岐を追加（非gitディレクトリ対応）
 - v1.7.4: Phase 5 の変更確認手順を統一（`git status --short --branch` + `git diff` + `git diff --cached`）

--- a/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
+++ b/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
@@ -78,6 +78,28 @@ esac
 
 printf -v TMUX_CMD 'tmux new-session -A -s %q -c %q' "$SESSION" "$REPO_ROOT"
 
+log() {
+  echo "[open_tmux_terminal] $*" >&2
+}
+
+session_exists_exact() {
+  local name="$1"
+  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -Fxq "$name"
+}
+
+wait_for_tmux_session() {
+  local retries="${1:-20}"
+  local delay="${2:-0.2}"
+  local i
+  for ((i = 1; i <= retries; i++)); do
+    if session_exists_exact "$SESSION"; then
+      return 0
+    fi
+    sleep "$delay"
+  done
+  return 1
+}
+
 escape_applescript() {
   local value="${1:-}"
   value="${value//\\/\\\\}"
@@ -95,7 +117,17 @@ is_iterm2_available() {
 
 is_ghostty_running() {
   local stdout
-  if stdout="$(osascript -e 'if application "Ghostty" is running then return "true" else return "false" end if' 2>/dev/null)"; then
+  local applescript
+  applescript=$(
+    cat <<'EOF'
+if application "Ghostty" is running then
+    return "true"
+else
+    return "false"
+end if
+EOF
+  )
+  if stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
     [[ "$stdout" == "true" ]]
     return
   fi
@@ -148,10 +180,15 @@ open_in_ghostty() {
       return 0
     fi
     if open_in_running_ghostty_tab; then
-      echo "Opened tmux in a new Ghostty tab."
-      return 0
+      if wait_for_tmux_session 15 0.2; then
+        echo "Opened tmux in a new Ghostty tab."
+        return 0
+      fi
+      log "Ghostty tab command was sent, but tmux session '$SESSION' was not created."
+    else
+      log "Ghostty tab open failed."
     fi
-    echo "Ghostty tab open failed, falling back to new window." >&2
+    log "Falling back to a new Ghostty window."
   fi
 
   if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -159,7 +196,12 @@ open_in_ghostty() {
     return 0
   fi
 
-  if ! open -a Ghostty.app --args -e /bin/bash -lc "$TMUX_CMD" >/dev/null 2>&1; then
+  if ! open -na Ghostty.app --args -e tmux new-session -A -s "$SESSION" -c "$REPO_ROOT" >/dev/null 2>&1; then
+    log "Ghostty new-window launch failed."
+    return 1
+  fi
+  if ! wait_for_tmux_session 25 0.2; then
+    log "Ghostty new-window command finished, but tmux session '$SESSION' was not created."
     return 1
   fi
   echo "Opened tmux in a new Ghostty window."

--- a/plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh
+++ b/plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh
@@ -7,7 +7,7 @@ Usage:
   send_claude_tmux_message.sh --target <session:window.pane> --file <message_file>
 
 Options:
-  --target <value>   tmux target (e.g. agent-team-foo:0.0)
+  --target <value>   tmux target (e.g. agent-team-foo:1.1)
   --file <path>      message text file path
   --sleep-ms <ms>    wait before Enter (default: 150)
   --no-verify        skip pane_current_command == claude check
@@ -65,10 +65,40 @@ if [[ ! -f "$MESSAGE_FILE" ]]; then
   exit 2
 fi
 
+target_session="${TARGET%%:*}"
+if [[ -z "$target_session" || "$target_session" == "$TARGET" ]]; then
+  echo "ERROR: invalid --target format (expected session:window.pane, got: $TARGET)" >&2
+  exit 2
+fi
+
+session_exists_exact() {
+  local name="$1"
+  tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -Fxq "$name"
+}
+
+if ! session_exists_exact "$target_session"; then
+  echo "ERROR: tmux session not found: $target_session" >&2
+  echo "HINT: run open_tmux_terminal.sh for session '$target_session' before sending messages." >&2
+  exit 1
+fi
+
+pane_inventory="$(tmux list-panes -t "$target_session" -F '#{session_name}:#{window_index}.#{pane_index} cmd=#{pane_current_command} active=#{pane_active}' 2>/dev/null || true)"
+pane_targets="$(printf '%s\n' "$pane_inventory" | cut -d ' ' -f1)"
+
+if ! printf '%s\n' "$pane_targets" | grep -Fxq "$TARGET"; then
+  echo "ERROR: target pane not found in session '$target_session' (target: $TARGET)" >&2
+  echo "Available panes:" >&2
+  printf '  %s\n' "$pane_inventory" >&2
+  exit 1
+fi
+
 if [[ "$VERIFY_PANE" -eq 1 ]]; then
   pane_cmd="$(tmux display-message -p -t "$TARGET" '#{pane_current_command}' 2>/dev/null || true)"
   if [[ "$pane_cmd" != "claude" ]]; then
     echo "ERROR: target pane is not claude (current: ${pane_cmd:-unknown}, target: $TARGET)" >&2
+    echo "Available panes in session '$target_session':" >&2
+    printf '  %s\n' "$pane_inventory" >&2
+    echo "HINT: start 'claude --dangerously-skip-permissions' in the target pane, then retry." >&2
     exit 1
   fi
 fi

--- a/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
@@ -110,36 +110,56 @@ claude --dangerously-skip-permissions
 ### ステップ 6: 送信スクリプトを設定（multi-agent-mcp の送信方式）
 
 ```bash
-TARGET="$SESSION:0.0"
+TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
+if [ -z "$TARGET" ]; then
+  TARGET="$(tmux list-panes -t "$SESSION" -F '#{session_name}:#{window_index}.#{pane_index}' | head -n 1)"
+fi
+if [ -z "$TARGET" ]; then
+  echo "ERROR: tmux target を解決できませんでした (session: $SESSION)" >&2
+  exit 1
+fi
+
+PANE_CMD="$(tmux display-message -p -t "$TARGET" '#{pane_current_command}' 2>/dev/null || true)"
+if [ "$PANE_CMD" != "claude" ]; then
+  echo "WARN: target pane is not claude (target: $TARGET, current: ${PANE_CMD:-unknown})"
+  echo "必要に応じて Step 5 の claude 起動をやり直してください。"
+fi
 
 SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
 ```
+
+- `TARGET` は固定値（`0.0`）を使わず tmux 実値で解決する
+- `base-index` / `pane-base-index` が `1` の環境でも同じ手順で動作する
 
 ### ステップ 7: 計画書を送信して Agent Team 実行を開始
 
 送信スクリプトは、本文貼り付け後に 2 通目の Enter を自動送信する。
 
 ```bash
+REPO_ROOT="$(pwd)"
 REQUEST_FILE="$(mktemp)"
-{
-  cat <<'EOF'
+COMMIT_NOTICE=""
+if [ "$FLOW_MODE" = "git" ]; then
+  COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+fi
+
+cat > "$REQUEST_FILE" <<EOF
 Agent Team を作成して、以下の計画書に従って実装を開始してください。
-EOF
-
-  if [ "$FLOW_MODE" = "git" ]; then
-    printf '%s\n' 'git add / commit / push は実行しないでください。'
-  fi
-
-  cat <<'EOF'
+報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
+${COMMIT_NOTICE}
 
 計画書:
 {plan_or_task}
 
-完了時は、実装サマリー・変更ファイル・テスト結果・残課題を報告してください。
+完了時は以下を報告してください。
+- 実装サマリー
+- 変更ファイル
+- テスト結果
+- 残課題
+
 完了時は以下コマンドを実行して macOS 通知を送ってください。
 osascript -e 'display notification "Agent Team 実装が完了しました" with title "agent-team-flow" sound name "default"'
 EOF
-} > "$REQUEST_FILE"
 bash "$SEND_SCRIPT" --target "$TARGET" --file "$REQUEST_FILE"
 rm -f "$REQUEST_FILE"
 ```
@@ -150,7 +170,8 @@ rm -f "$REQUEST_FILE"
 - 進捗確認が必要な場合は tmux 出力を確認
 
 ```bash
-tmux capture-pane -pt "$SESSION":0.0 | tail -n 120
+CAPTURE_TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || tmux list-panes -t "$SESSION" -F '#{session_name}:#{window_index}.#{pane_index}' | head -n 1)"
+tmux capture-pane -pt "$CAPTURE_TARGET" | tail -n 120
 ```
 
 ## Phase 2-4: Agent Team の自律実行
@@ -175,7 +196,8 @@ no-git モード:
 - 必要に応じて以下で tmux 出力を再確認
 
 ```bash
-tmux capture-pane -pt "$SESSION":0.0 | tail -n 200
+CAPTURE_TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || tmux list-panes -t "$SESSION" -F '#{session_name}:#{window_index}.#{pane_index}' | head -n 1)"
+tmux capture-pane -pt "$CAPTURE_TARGET" | tail -n 200
 ```
 
 ### ステップ 2: ユーザー承認を取得（必須）
@@ -254,24 +276,24 @@ no-git モード:
 
 ```bash
 USER_FEEDBACK="{user_feedback}"
+REPO_ROOT="$(pwd)"
 FIX_FILE="$(mktemp)"
-{
-  cat <<'EOF'
+COMMIT_NOTICE=""
+if [ "$FLOW_MODE" = "git" ]; then
+  COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+fi
+
+cat > "$FIX_FILE" <<EOF
 Agent Team を作成して、以下の修正指示に従って実装を開始してください。
-EOF
+報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
+${COMMIT_NOTICE}
 
-  if [ "$FLOW_MODE" = "git" ]; then
-    printf '%s\n' 'コミット（git add / commit / push）は行わないでください。'
-  fi
+修正依頼: ${USER_FEEDBACK}
 
-  printf '\n修正依頼: %s\n\n' "$USER_FEEDBACK"
-
-  cat <<'EOF'
 上記を反映し、完了時は実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
 完了時は以下コマンドを実行して macOS 通知を送ってください。
 osascript -e 'display notification "Agent Team 修正対応が完了しました" with title "agent-team-flow" sound name "default"'
 EOF
-} > "$FIX_FILE"
 bash "$SEND_SCRIPT" --target "$TARGET" --file "$FIX_FILE"
 rm -f "$FIX_FILE"
 ```

--- a/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
@@ -85,27 +85,52 @@ claude --dangerously-skip-permissions
 ### ステップ 5: 送信スクリプトを設定（multi-agent-mcp の送信方式）
 
 ```bash
-TARGET="$SESSION:0.0"
+TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
+if [ -z "$TARGET" ]; then
+  TARGET="$(tmux list-panes -t "$SESSION" -F '#{session_name}:#{window_index}.#{pane_index}' | head -n 1)"
+fi
+if [ -z "$TARGET" ]; then
+  echo "ERROR: tmux target を解決できませんでした (session: $SESSION)" >&2
+  exit 1
+fi
+
+PANE_CMD="$(tmux display-message -p -t "$TARGET" '#{pane_current_command}' 2>/dev/null || true)"
+if [ "$PANE_CMD" != "claude" ]; then
+  echo "WARN: target pane is not claude (target: $TARGET, current: ${PANE_CMD:-unknown})"
+  echo "必要に応じて Step 4 の claude 起動をやり直してください。"
+fi
 
 SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
 ```
+
+- `TARGET` は固定値（`0.0`）を使わず tmux 実値で解決する
+- `base-index` / `pane-base-index` が `1` の環境でも同じ手順で動作する
 
 ### ステップ 6: 計画書を送信して Agent Team 実行を開始
 
 送信スクリプトは、本文貼り付け後に 2 通目の Enter を自動送信する。
 
 ```bash
+REPO_ROOT="$(pwd)"
 REQUEST_FILE="$(mktemp)"
-cat > "$REQUEST_FILE" <<'EOF'
+COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+
+cat > "$REQUEST_FILE" <<EOF
 Issue #{issue_number} の対応を開始してください。以下の計画書に従って実装してください。
-git add / commit / push は実行しないでください。
+報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
+${COMMIT_NOTICE}
 
 計画書:
 {plan_or_task}
 
-- 完了条件: 実装、テスト、変更サマリー、残課題の報告
-- 完了時は以下コマンドを実行して macOS 通知を送る
-  osascript -e 'display notification "Agent Team Issue 実装が完了しました" with title "agent-team-issue-flow" sound name "default"'
+完了時は以下を報告してください。
+- 実装サマリー
+- 変更ファイル
+- テスト結果
+- 残課題
+
+完了時は以下コマンドを実行して macOS 通知を送ってください。
+osascript -e 'display notification "Agent Team Issue 実装が完了しました" with title "agent-team-issue-flow" sound name "default"'
 EOF
 bash "$SEND_SCRIPT" --target "$TARGET" --file "$REQUEST_FILE"
 rm -f "$REQUEST_FILE"
@@ -117,7 +142,8 @@ rm -f "$REQUEST_FILE"
 - 進捗確認が必要な場合は tmux 出力を確認
 
 ```bash
-tmux capture-pane -pt "$SESSION":0.0 | tail -n 120
+CAPTURE_TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || tmux list-panes -t "$SESSION" -F '#{session_name}:#{window_index}.#{pane_index}' | head -n 1)"
+tmux capture-pane -pt "$CAPTURE_TARGET" | tail -n 120
 ```
 
 ## Phase 2-4: Agent Team の自律実行
@@ -222,10 +248,14 @@ Closes #{issue_number}
 
 ```bash
 USER_FEEDBACK="{user_feedback}"
+REPO_ROOT="$(pwd)"
 FIX_FILE="$(mktemp)"
+COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+
 cat > "$FIX_FILE" <<EOF
 Agent Team を作成して、以下の修正指示に従って実装を開始してください。
-コミット（git add / commit / push）は行わないでください。
+報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
+${COMMIT_NOTICE}
 
 修正依頼: ${USER_FEEDBACK}
 
@@ -237,7 +267,7 @@ bash "$SEND_SCRIPT" --target "$TARGET" --file "$FIX_FILE"
 rm -f "$FIX_FILE"
 ```
 
-1. Phase 2-4 に戻って再実行
+2. Phase 2-4 に戻って再実行
 
 ### 保留の場合
 


### PR DESCRIPTION
## 概要

Agent Team 起動フローの不具合修正とドキュメント整合を行いました。

## 変更内容

- Ghostty 起動判定とフォールバック挙動を改善し、tmux セッション作成確認を追加
- Ghostty 新規ウィンドウ起動を `open -na Ghostty.app --args ...` に変更
- `send_claude_tmux_message.sh` に target/session/pane の事前検証と原因別エラー出力を追加
- 2つの SKILL で `TARGET` を tmux 実値で動的解決するよう更新
- `agent-team-flow` / `agent-team-issue-flow` の依頼テンプレート形式を統一
- README とバージョンを `1.8.2` に更新

## 関連 Issue

Closes #117

## テスト

- [x] `bash -n plugins/shiiman-workflow/scripts/open_tmux_terminal.sh`
- [x] `bash -n plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh`
- [x] `pytest -q tests/test_plugin_json.py`
