### PR TITLE
fix: Agent Team承認時のクリーンアップを直接実行に統一

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/README.md
+++ b/plugins/shiiman-workflow/README.md
@@ -182,6 +182,7 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 
 ## バージョン履歴
 
+- v1.8.3: Agent Team 承認時のクリーンアップを「送信指示」から「実行側の直接実行」に変更し、依頼テンプレート形式を統一
 - v1.8.2: Ghostty 起動フォールバックと tmux target 解決を修正（`0.0` 固定を廃止し実値解決へ変更）
 - v1.8.1: `agent-team-flow` / `agent-team-issue-flow` のターミナル起動を共通化し、既存起動時の新規タブ化と文字化け対策を修正
 - v1.8.0: `multi-flow` / `agent-team-flow` に `--no-git` と git/no-git 自動分岐を追加（非gitディレクトリ対応）

--- a/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-flow/SKILL.md
@@ -214,15 +214,12 @@ options:
 
 ### OK（承認）の場合
 
-1. 送信スクリプトで Claude Code へクリーンアップ指示を送信
+1. 実行側で tmux セッションを直接クリーンアップ
 
 ```bash
-APPROVAL_FILE="$(mktemp)"
-cat > "$APPROVAL_FILE" <<'EOF'
-実装を承認します。Agent Team をクリーンアップして、最終サマリーを出してください。
-EOF
-bash "$SEND_SCRIPT" --target "$TARGET" --file "$APPROVAL_FILE"
-rm -f "$APPROVAL_FILE"
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  tmux kill-session -t "$SESSION"
+fi
 ```
 
 2. セキュリティチェック

--- a/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
@@ -174,15 +174,12 @@ options:
 
 ### OK（承認）の場合
 
-1. 送信スクリプトで Claude Code へクリーンアップ指示を送信
+1. 実行側で tmux セッションを直接クリーンアップ
 
 ```bash
-APPROVAL_FILE="$(mktemp)"
-cat > "$APPROVAL_FILE" <<'EOF'
-実装を承認します。Agent Team をクリーンアップして、最終サマリーを出してください。
-EOF
-bash "$SEND_SCRIPT" --target "$TARGET" --file "$APPROVAL_FILE"
-rm -f "$APPROVAL_FILE"
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  tmux kill-session -t "$SESSION"
+fi
 ```
 
 2. セキュリティチェック


### PR DESCRIPTION
## 概要

Agent Team スキルの承認フローを調整し、クリーンアップを送信依頼ではなく実行側が直接実行する方式に統一しました。
また、プラグイン更新手順に沿って `shiiman-workflow` のバージョンを更新しています。

## 変更内容

- `agent-team-flow` の承認ステップを `tmux kill-session` 直接実行へ変更
- `agent-team-issue-flow` の承認ステップを `tmux kill-session` 直接実行へ変更
- `plugin.json` を `1.8.3` へ更新
- `marketplace.json` の `shiiman-workflow` を `1.8.3` へ同期
- README のバージョン履歴へ `v1.8.3` を追加

## 関連 Issue

Closes #119

## テスト

- [x] `pytest -q tests/test_plugin_json.py`
