### PR TITLE
fix: agent-team-issue-flow の依頼文を Agent Team 前提に修正

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/README.md
+++ b/plugins/shiiman-workflow/README.md
@@ -184,6 +184,7 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 
 ## バージョン履歴
 
+- v1.8.6: `agent-team-issue-flow` の Step 6 送信テンプレート先頭を `Agent Team を作成して` へ修正し、実行意図を明確化
 - v1.8.5: `open_tmux_terminal.sh` に `--state-file` を追加し、`cleanup_tmux_terminal.sh` を新規追加。Agent Team 承認時は tmux を常に終了し、window 起動時のみ terminal をクローズする仕様へ変更
 - v1.8.4: `agent-team-flow` / `agent-team-issue-flow` の送信テンプレートを `>|` に統一して `zsh noclobber` を回避。`send_claude_tmux_message.sh` に空ファイルガードを追加
 - v1.8.3: Agent Team 承認時のクリーンアップを「送信指示」から「実行側の直接実行」に変更し、依頼テンプレート形式を統一

--- a/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md
@@ -122,7 +122,7 @@ REQUEST_FILE="$(mktemp)"
 COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 
 cat >| "$REQUEST_FILE" <<EOF
-Issue #{issue_number} の対応を開始してください。以下の計画書に従って実装してください。
+Agent Team を作成して、Issue #{issue_number} の対応を開始してください。以下の計画書に従って実装してください。
 報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
 ${COMMIT_NOTICE}
 


### PR DESCRIPTION
## 概要

`agent-team-issue-flow` の Step 6 送信テンプレートを Agent Team 実行前提に修正し、あわせて `shiiman-workflow` のバージョンを `1.8.6` へ更新しました。

## 変更内容

- `plugins/shiiman-workflow/skills/agent-team-issue-flow/SKILL.md`
  - 送信テンプレート先頭を `Agent Team を作成して、Issue #{issue_number} の対応を開始してください。` に修正
- `plugins/shiiman-workflow/.claude-plugin/plugin.json`
  - バージョンを `1.8.5` → `1.8.6` に更新
- `.claude-plugin/marketplace.json`
  - `shiiman-workflow` エントリのバージョンを `1.8.5` → `1.8.6` に更新
- `plugins/shiiman-workflow/README.md`
  - バージョン履歴に `v1.8.6` を追加

## 関連 Issue

Closes #125

## テスト計画

- [x] `jq empty plugins/shiiman-workflow/.claude-plugin/plugin.json`
- [x] `jq empty .claude-plugin/marketplace.json`
- [x] `jq -r '.version' plugins/shiiman-workflow/.claude-plugin/plugin.json` と `.claude-plugin/marketplace.json` の一致確認

## チェックリスト

- [x] 命名規則に従っている
- [x] README.md を更新した（必要な場合）
- [x] 動作確認済み
