### PR TITLE
fix: shiiman-google/terraform/slack のバージョン上げ忘れを修正

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
     {
       "name": "shiiman-google",
       "description": "Google Workspace 操作 - 認証、Drive 検索、Docs/Sheets/Slides/Forms/Apps Script 編集、Calendar、Gmail 未読管理を提供",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "source": "./plugins/shiiman-google",
       "category": "productivity"
     },
@@ -47,14 +47,14 @@
     {
       "name": "shiiman-terraform",
       "description": "Terraform リソース import 支援プラグイン",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "source": "./plugins/shiiman-terraform",
       "category": "developer-tools"
     },
     {
       "name": "shiiman-slack",
       "description": "Slack 通知管理 - 未読確認、既読化、メンション確認・返信、プロフィール更新を提供",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "source": "./plugins/shiiman-slack",
       "category": "productivity"
     }

--- a/plugins/shiiman-google/.claude-plugin/plugin.json
+++ b/plugins/shiiman-google/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-google",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Google Workspace 操作 - 認証、Drive 検索、Docs/Sheets/Slides/Forms/Apps Script 編集、Calendar、Gmail 未読管理を提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-slack/.claude-plugin/plugin.json
+++ b/plugins/shiiman-slack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-slack",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Slack 通知管理 - 未読確認、既読化、メンション確認・返信、プロフィール更新を提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-terraform/.claude-plugin/plugin.json
+++ b/plugins/shiiman-terraform/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-terraform",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Terraform リソース import 支援プラグイン",
   "author": {
     "name": "shiiman"


### PR DESCRIPTION
## 概要

#144 で argument-hint + Help セクションを追加した際に、shiiman-google / shiiman-terraform / shiiman-slack のバージョンバンプが漏れていたため修正。

## 変更内容

| プラグイン | 旧バージョン | 新バージョン |
|---|---|---|
| shiiman-google | 2.0.0 | 2.0.1 |
| shiiman-terraform | 2.0.0 | 2.0.1 |
| shiiman-slack | 3.0.0 | 3.0.1 |

- plugin.json と marketplace.json の両方を更新

## テスト計画

- [ ] `claude plugin validate .` → 警告なし