### PR TITLE
chore: .gitignore に .pytest_cache/ を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn-error.log*
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 .env
 .venv/
 venv/


### PR DESCRIPTION
## 概要

Python セクションに `.pytest_cache/` を追加。

## テスト計画

- [ ] `.gitignore` に `.pytest_cache/` が含まれることを確認