### PR TITLE
feat!: shiiman-workflow スキル名を workflow-* 形式にリネーム（v2.0.0）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "1.8.8",
+      "version": "2.0.0",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,12 @@ plugins/{plugin-name}/
 
 ### Workflow
 
-- `/shiiman-workflow:single-issue-flow` - Single-agent flow: Issue creation → implementation → PR (trigger: "シングル Issue フロー")
-- `/shiiman-workflow:multi-issue-flow` - Multi-agent flow: parallel Issue-based development with MCP (trigger: "マルチ Issue フロー")
-- `/shiiman-workflow:single-flow` - Lightweight single-agent flow without Issue/PR (trigger: "シングルフロー")
-- `/shiiman-workflow:multi-flow` - Lightweight multi-agent parallel flow without Issue/PR (trigger: "マルチフロー")
+- `/shiiman-workflow:workflow-single-issue` - Single-agent flow: Issue creation → implementation → PR (trigger: "シングル Issue フロー")
+- `/shiiman-workflow:workflow-multi-issue` - Multi-agent flow: parallel Issue-based development with MCP (trigger: "マルチ Issue フロー")
+- `/shiiman-workflow:workflow-single` - Lightweight single-agent flow without Issue/PR (trigger: "シングルフロー")
+- `/shiiman-workflow:workflow-multi` - Lightweight multi-agent parallel flow without Issue/PR (trigger: "マルチフロー")
+- `/shiiman-workflow:workflow-agent-team` - Agent Team lightweight parallel flow without Issue/PR (trigger: "エージェントチームフロー")
+- `/shiiman-workflow:workflow-agent-team-issue` - Agent Team flow: Issue creation → parallel implementation → PR (trigger: "Agent Team Issue")
 
 ### GitHub Operations
 

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ pip install -r requirements.txt
 
 | スキル | プラグイン | トリガー例 | 説明 |
 |--------|-----------|------------|------|
-| single-issue-flow | shiiman-workflow | 「シングル Issue フロー」「Issue から PR まで」 | Issue 作成から PR 作成まで自動実行するシングルエージェントフロー |
-| multi-issue-flow | shiiman-workflow | 「マルチ Issue フロー」「並列 Issue 開発」 | MCP マルチエージェントで Issue から PR まで並列実行 |
-| single-flow | shiiman-workflow | 「シングルフロー」「軽量フロー」 | Issue/PR なしで計画書からタスク実行する軽量フロー |
-| multi-flow | shiiman-workflow | 「マルチフロー」「並列軽量フロー」 | MCP マルチエージェントで Issue/PR なしに並列実行する軽量フロー |
-| agent-team-issue-flow | shiiman-workflow | 「agent-team-issue-flow」「Agent Team Issue」 | Agent Team で Issue から PR まで並列実行 |
-| agent-team-flow | shiiman-workflow | 「agent-team-flow」「エージェントチームフロー」 | Agent Team で Issue/PR なしに並列実行する軽量フロー |
+| workflow-single-issue | shiiman-workflow | 「シングル Issue フロー」「Issue から PR まで」 | Issue 作成から PR 作成まで自動実行するシングルエージェントフロー |
+| workflow-multi-issue | shiiman-workflow | 「マルチ Issue フロー」「並列 Issue 開発」 | MCP マルチエージェントで Issue から PR まで並列実行 |
+| workflow-single | shiiman-workflow | 「シングルフロー」「軽量フロー」 | Issue/PR なしで計画書からタスク実行する軽量フロー |
+| workflow-multi | shiiman-workflow | 「マルチフロー」「並列軽量フロー」 | MCP マルチエージェントで Issue/PR なしに並列実行する軽量フロー |
+| workflow-agent-team-issue | shiiman-workflow | 「Agent Team Issue」「エージェントチーム Issue フロー」 | Agent Team で Issue から PR まで並列実行 |
+| workflow-agent-team | shiiman-workflow | 「エージェントチームフロー」「Agent Team で実装」 | Agent Team で Issue/PR なしに並列実行する軽量フロー |
 
 GitHub の Issue/PR 操作は、このリポジトリのローカル `.claude` スキルではなく、グローバルまたは `shiiman-git` 側のスキルを利用してください。
 

--- a/plugins/shiiman-git/README.md
+++ b/plugins/shiiman-git/README.md
@@ -96,9 +96,9 @@ claude plugin install shiiman-git@shiiman-claude-code-plugins
 ## ワークフローガイド
 
 > **開発フローについて**: Issue → 実装 → PR の自動開発フローは `shiiman-workflow` プラグインをご利用ください。
-> - `single-issue-flow`: シングルエージェントで Issue から PR まで
-> - `multi-issue-flow`: マルチエージェントで並列実行
-> - `single-flow` / `multi-flow`: Issue/PR なしの軽量フロー
+> - `workflow-single-issue`: シングルエージェントで Issue から PR まで
+> - `workflow-multi-issue`: マルチエージェントで並列実行
+> - `workflow-single` / `workflow-multi`: Issue/PR なしの軽量フロー
 
 ### 手動フロー
 

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "1.8.8",
+  "version": "2.0.0",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/README.md
+++ b/plugins/shiiman-workflow/README.md
@@ -17,20 +17,20 @@ claude plugin install shiiman-workflow@shiiman-claude-code-plugins
 
 | スキル | Issue | ブランチ | PR | エージェント | 用途 |
 |--------|-------|----------|-----|--------------|------|
-| single-issue-flow | ✅ | ✅ | ✅ | シングル | 標準的な開発フロー |
-| single-flow | ❌ | ✅ | ❌ | シングル | 軽量な実装タスク |
-| multi-issue-flow | ✅ | ✅ | ✅ | マルチ | 大規模な開発タスク |
-| multi-flow | ❌ | ✅/❌ | ❌ | マルチ | 並列実装タスク（`--no-git` / 自動判定で非git対応） |
-| agent-team-issue-flow | ✅ | ✅ | ✅ | Agent Team | Agent Team で Issue から PR まで |
-| agent-team-flow | ❌ | ✅/❌ | ❌ | Agent Team | Agent Team 軽量並列実装（`--no-git` / 自動判定で非git対応） |
+| workflow-single-issue | ✅ | ✅ | ✅ | シングル | 標準的な開発フロー |
+| workflow-single | ❌ | ✅ | ❌ | シングル | 軽量な実装タスク |
+| workflow-multi-issue | ✅ | ✅ | ✅ | マルチ | 大規模な開発タスク |
+| workflow-multi | ❌ | ✅/❌ | ❌ | マルチ | 並列実装タスク（`--no-git` / 自動判定で非git対応） |
+| workflow-agent-team-issue | ✅ | ✅ | ✅ | Agent Team | Agent Team で Issue から PR まで |
+| workflow-agent-team | ❌ | ✅/❌ | ❌ | Agent Team | Agent Team 軽量並列実装（`--no-git` / 自動判定で非git対応） |
 
 ## スキル
 
-### single-issue-flow
+### workflow-single-issue
 
 Issue から PR まで自動実行するシングルエージェントフロー。
 
-**トリガー例**: 「シングル Issue フロー」「Issue から PR まで」「single-issue-flow」
+**トリガー例**: 「シングル Issue フロー」「Issue から PR まで」「workflow-single-issue」
 
 **フロー**:
 
@@ -44,11 +44,11 @@ Issue から PR まで自動実行するシングルエージェントフロー�
 - `--plan`: 計画書を作成してから実行
 - `タスク説明`: 計画書なしで直接実行
 
-### single-flow
+### workflow-single
 
 Issue/PR なしで軽量に実行するフロー。
 
-**トリガー例**: 「シングルフロー」「軽量フロー」「single-flow」
+**トリガー例**: 「シングルフロー」「軽量フロー」「workflow-single」
 
 **フロー**:
 
@@ -63,11 +63,11 @@ Issue/PR なしで軽量に実行するフロー。
 - PR を作成しない
 - コミットメッセージを出力して終了（手動でコミット）
 
-### multi-issue-flow
+### workflow-multi-issue
 
 MCP マルチエージェントで並列実行する開発フロー。
 
-**トリガー例**: 「マルチ Issue フロー」「並列 Issue 開発」「multi-issue-flow」
+**トリガー例**: 「マルチ Issue フロー」「並列 Issue 開発」「workflow-multi-issue」
 
 **前提条件**:
 
@@ -86,11 +86,11 @@ MCP マルチエージェントで並列実行する開発フロー。
 - Admin（1）: タスク分配と Worker 管理
 - Worker（max 16）: 各サブタスクを並列実行
 
-### multi-flow
+### workflow-multi
 
 MCP マルチエージェントで並列実行する軽量フロー。
 
-**トリガー例**: 「マルチフロー」「並列フロー」「multi-flow」
+**トリガー例**: 「マルチフロー」「並列フロー」「workflow-multi」
 
 **前提条件**:
 
@@ -114,11 +114,11 @@ no-git モード: 計画書 → MCP初期化(enable_git=false) → 並列実行 
 - 複数 Worker が並列実行
 - git モードでは統合後にコミットメッセージを出力
 
-### agent-team-issue-flow
+### workflow-agent-team-issue
 
 Agent Team で Issue から PR まで並列実行する開発フロー。
 
-**トリガー例**: 「agent-team-issue-flow」「エージェントチーム Issue フロー」「Agent Team Issue」
+**トリガー例**: 「workflow-agent-team-issue」「エージェントチーム Issue フロー」「Agent Team Issue」
 
 **フロー**:
 
@@ -128,7 +128,7 @@ Agent Team で Issue から PR まで並列実行する開発フロー。
 
 **特徴**:
 
-- `multi-issue-flow` の MCP 使用部分を Agent Team 実行に置き換え
+- `workflow-multi-issue` の MCP 使用部分を Agent Team 実行に置き換え
 - `claude --dangerously-skip-permissions` で Agent Team 実行
 - ターミナル起動は `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を使用（既存起動時は新規タブ、未起動時は新規ウィンドウ先頭タブ）
 - 承認時クリーンアップは `plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh` を使用（tmux は常に終了、window 起動時のみ terminal をクローズ）
@@ -136,11 +136,11 @@ Agent Team で Issue から PR まで並列実行する開発フロー。
 - tmux メッセージ送信先 target は固定値ではなく tmux 実値から動的解決
 - 2 つの Agent Team スキルで共通利用する送信スクリプトは `plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh` を使用
 
-### agent-team-flow
+### workflow-agent-team
 
 Agent Team で Issue/PR なしに並列実行する軽量フロー。
 
-**トリガー例**: 「agent-team-flow」「エージェントチームフロー」「Agent Team で実装」
+**トリガー例**: 「workflow-agent-team」「エージェントチームフロー」「Agent Team で実装」
 
 **フロー**:
 
@@ -151,7 +151,7 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 
 **特徴**:
 
-- `multi-flow` の MCP 使用部分を Agent Team 実行に置き換え
+- `workflow-multi` の MCP 使用部分を Agent Team 実行に置き換え
 - `claude --dangerously-skip-permissions` で Agent Team 実行
 - `--no-git` 指定時、または `git rev-parse --is-inside-work-tree` 失敗時は no-git モードへ切替
 - no-git モードではブランチ作成と push 前提手順を行わない
@@ -169,12 +169,12 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 - GitHub CLI (`gh`) がインストール済み
 - `gh auth login` で認証済み
 
-### マルチエージェントスキル（multi-*）
+### マルチエージェントスキル（workflow-multi-*）
 
 - multi-agent-mcp がインストール済み
 - tmux がインストール済み
 
-### Agent Team スキル（agent-team-*）
+### Agent Team スキル（workflow-agent-team-*）
 
 - `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` を有効化
 - `CLAUDE_PLUGIN_ROOT` が利用可能なプラグイン実行コンテキストで実行
@@ -184,16 +184,17 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 
 ## バージョン履歴
 
-- v1.8.7: `single-*` / `multi-*` / `agent-team-*` のブランチ作成手順を `main` 固定から `gh repo view --json defaultBranchRef` によるデフォルトブランチ取得へ変更
-- v1.8.6: `agent-team-issue-flow` の Step 6 送信テンプレート先頭を `Agent Team を作成して` へ修正し、実行意図を明確化
+- v2.0.0: 全スキルを `workflow-*` 形式にリネーム（破壊的変更）
+- v1.8.7: ブランチ作成手順を `main` 固定から `gh repo view --json defaultBranchRef` によるデフォルトブランチ取得へ変更
+- v1.8.6: Agent Team Issue の Step 6 送信テンプレート先頭を `Agent Team を作成して` へ修正し、実行意図を明確化
 - v1.8.5: `open_tmux_terminal.sh` に `--state-file` を追加し、`cleanup_tmux_terminal.sh` を新規追加。Agent Team 承認時は tmux を常に終了し、window 起動時のみ terminal をクローズする仕様へ変更
-- v1.8.4: `agent-team-flow` / `agent-team-issue-flow` の送信テンプレートを `>|` に統一して `zsh noclobber` を回避。`send_claude_tmux_message.sh` に空ファイルガードを追加
+- v1.8.4: Agent Team スキルの送信テンプレートを `>|` に統一して `zsh noclobber` を回避。`send_claude_tmux_message.sh` に空ファイルガードを追加
 - v1.8.3: Agent Team 承認時のクリーンアップを「送信指示」から「実行側の直接実行」に変更し、依頼テンプレート形式を統一
 - v1.8.2: Ghostty 起動フォールバックと tmux target 解決を修正（`0.0` 固定を廃止し実値解決へ変更）
-- v1.8.1: `agent-team-flow` / `agent-team-issue-flow` のターミナル起動を共通化し、既存起動時の新規タブ化と文字化け対策を修正
-- v1.8.0: `multi-flow` / `agent-team-flow` に `--no-git` と git/no-git 自動分岐を追加（非gitディレクトリ対応）
+- v1.8.1: Agent Team スキルのターミナル起動を共通化し、既存起動時の新規タブ化と文字化け対策を修正
+- v1.8.0: マルチ / Agent Team 軽量フローに `--no-git` と git/no-git 自動分岐を追加（非gitディレクトリ対応）
 - v1.7.4: Phase 5 の変更確認手順を統一（`git status --short --branch` + `git diff` + `git diff --cached`）
-- v1.7.1: agent-team-flow / agent-team-issue-flow を仕様準拠に修正（Ghostty/iTerm2 + tmux + Agent Team 実行フローへ統一）
+- v1.7.1: Agent Team スキルを仕様準拠に修正（Ghostty/iTerm2 + tmux + Agent Team 実行フローへ統一）
 - v1.5.0: SKILL.md を約 60% スリム化。MCP 側で Admin/Worker 指示を自動生成
 - v1.4.0: Worker 数をデフォルト 6、最大 16 に変更。MCP 自動機能（ペルソナ、メモリ、7セクション構造）を統合
 - v1.0.0: 初期リリース（shiiman-git の dev-flow から移行）

--- a/plugins/shiiman-workflow/skills/workflow-agent-team-issue/SKILL.md
+++ b/plugins/shiiman-workflow/skills/workflow-agent-team-issue/SKILL.md
@@ -1,41 +1,39 @@
 ---
-name: agent-team-flow
-description: Agent Team で Issue/PR なしの並列実装を実行する軽量フロー。「agent-team-flow」「エージェントチームフロー」「チーム並列実装」「Agent Team で実装」「チーム軽量フロー」「並列チーム開発」「Agent Team 軽量」などで起動。multi-flow の MCP 使用部分を Agent Team に置き換えて実行。
+name: workflow-agent-team-issue
+description: Agent Team で Issue から PR まで並列実行する開発フロー。「workflow-agent-team-issue」「エージェントチーム Issue フロー」「チーム Issue 開発」「Agent Team Issue」「Issue から並列実装」「チームで PR 作成」「Agent Team で Issue 対応」などで起動。workflow-multi-issue の MCP 使用部分を Agent Team に置き換えて実行。
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, EnterPlanMode, TodoWrite]
 context: fork
 user-invocable: true
-argument-hint: "[タスク説明] [--plan|--no-git|--help]"
+argument-hint: "[タスク説明] [--plan|--help]"
 ---
 
-# Agent Team Flow
+# Agent Team Issue Flow
 
-Agent Team で Issue/PR なしに並列実装を進める軽量フロー。
-`multi-flow` のうち MCP 依存部分を Agent Team 実行に置き換えます。
+Agent Team で Issue 作成から PR 作成までを並列実行するフロー。
+`workflow-multi-issue` のうち MCP 依存部分を Agent Team 実行に置き換えます。
 
 ## Help
 
 `$ARGUMENTS` に `--help` が含まれる場合、以下を表示して終了:
 
 ```text
-/agent-team-flow - Agent Team 軽量フロー
+/workflow-agent-team-issue - Agent Team Issue 開発フロー
 
 概要:
-  Agent Team で Issue/PR なしに並列実装を実行する。
-  ブランチ作成 → tmux + Claude 起動 → Agent Team 並列実行 → コミットメッセージ出力。
+  Agent Team で Issue 作成から PR 作成まで並列実行する。
+  Issue 作成 → tmux + Claude 起動 → Agent Team 並列実行 → コミット → PR 作成。
 
 使用方法:
-  /agent-team-flow [タスク説明] [オプション]
+  /workflow-agent-team-issue [タスク説明] [オプション]
 
 オプション:
-  --plan    plan mode で計画書を新規作成してから実行
-  --no-git  git を使わず no-git モードで実行
-  --help    このヘルプを表示
+  --plan  plan mode で計画書を新規作成してから実行
+  --help  このヘルプを表示
 
 例:
-  /agent-team-flow                        # 既存計画書から実行
-  /agent-team-flow --plan                 # 計画書を作成してから実行
-  /agent-team-flow "API リファクタリング"  # タスク説明から直接実行
-  /agent-team-flow --no-git               # git なしモードで実行
+  /workflow-agent-team-issue                        # 既存計画書から実行
+  /workflow-agent-team-issue --plan                 # 計画書を作成してから実行
+  /workflow-agent-team-issue "認証機能を並列実装"    # タスク説明から直接実行
 ```
 
 ## 前提条件
@@ -43,66 +41,42 @@ Agent Team で Issue/PR なしに並列実装を進める軽量フロー。
 - `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` が設定済み（必須）
 - `claude` コマンドが利用可能
 - `tmux` が利用可能
-- `gh` コマンドが利用可能
 - `gh auth status` が成功する（GitHub CLI 認証済み）
 - macOS で `Ghostty` または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
-
-## 実行モード判定（重要）
-
-優先順位は以下。
-
-1. `--no-git` 指定あり: 常に no-git モード
-2. `--no-git` 指定なし + `git rev-parse --is-inside-work-tree` 成功: git モード
-3. それ以外: no-git モード
-
-判定コマンド:
-
-```bash
-git rev-parse --is-inside-work-tree >/dev/null 2>&1
-```
-
-## セッション名 / slug ルール
-
-- slug はタスク内容から簡潔な英語キーワードで作成
-- slug を生成できない場合は `no-git-task` を使用
-- tmux セッション名は `agent-team-{slug}` を使用
 
 ## 実行フロー
 
 ```text
-git モード:
-Phase 1: ブランチ作成 → ターミナル + tmux 起動 → claude 起動 → 計画書送信
+Phase 1: Issue 作成 → ブランチ作成 → ターミナル + tmux 起動 → claude 起動 → 計画書送信
 Phase 2-4: Agent Team が計画書を読み取り自律実装
-Phase 5: 結果確認 → 承認/修正依頼 → クリーンアップ → コミットメッセージ出力
-
-no-git モード:
-Phase 1: ターミナル + tmux 起動 → claude 起動 → 計画書送信
-Phase 2-4: Agent Team が計画書を読み取り自律実装
-Phase 5: 結果確認（Agent Team 報告）→ 承認/修正依頼 → クリーンアップ
+Phase 5: 結果確認 → 承認/修正依頼 → クリーンアップ → Issue 更新 → コミット/Push → PR 作成
 ```
 
-## Phase 1: セットアップと Agent Team 起動
+## Phase 1: Issue 作成と Agent Team 起動
 
-### ステップ 1: 実行モード判定
+### ステップ 1: Issue 作成
 
 ```bash
-if [ "{no_git_flag}" = "true" ]; then
-  FLOW_MODE="no-git"
-elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  FLOW_MODE="git"
-else
-  FLOW_MODE="no-git"
-fi
+gh repo view --json owner,name
+gh issue create --title "{title}" --body "{body}" --label "{label}"
 ```
 
-### ステップ 2: slug を決定
+Issue 本文テンプレート:
 
-```text
-slug = {task_slug}
-if slug が空なら slug = "no-git-task"
+```markdown
+## 概要
+{目的・背景}
+
+## タスク一覧
+- [ ] Task 1: {subtask}
+- [ ] Task 2: {subtask}
+
+## 完了条件
+- 全 Task が完了
+- テスト通過
 ```
 
-### ステップ 3: git モード時のみブランチ作成
+### ステップ 2: ブランチ作成
 
 ```bash
 DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')"
@@ -114,16 +88,15 @@ fi
 git fetch origin "$DEFAULT_BRANCH"
 git checkout "$DEFAULT_BRANCH"
 git pull origin "$DEFAULT_BRANCH"
-git checkout -b feature/{slug}
+git checkout -b feature/{issue_number}
 ```
 
-no-git モードではこのステップをスキップする。
 ユーザーがベースブランチを明示した場合は、そちらを優先する。
 
-### ステップ 4: 共通スクリプトで tmux セッションを起動
+### ステップ 3: 共通スクリプトで tmux セッションを起動
 
 ```bash
-SESSION="agent-team-{slug}"
+SESSION="agent-team-issue-{issue_number}"
 REPO_ROOT="$(pwd)"
 OPEN_TMUX_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/open_tmux_terminal.sh"
 CLEANUP_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/cleanup_tmux_terminal.sh"
@@ -136,13 +109,13 @@ bash "$OPEN_TMUX_SCRIPT" \
   --state-file "$TERMINAL_STATE_FILE"
 ```
 
-### ステップ 5: tmux 内で Claude Code を起動
+### ステップ 4: tmux 内で Claude Code を起動
 
 ```bash
 claude --dangerously-skip-permissions
 ```
 
-### ステップ 6: 送信スクリプトを設定（multi-agent-mcp の送信方式）
+### ステップ 5: 送信スクリプトを設定（multi-agent-mcp の送信方式）
 
 ```bash
 TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
@@ -157,7 +130,7 @@ fi
 PANE_CMD="$(tmux display-message -p -t "$TARGET" '#{pane_current_command}' 2>/dev/null || true)"
 if [ "$PANE_CMD" != "claude" ]; then
   echo "WARN: target pane is not claude (target: $TARGET, current: ${PANE_CMD:-unknown})"
-  echo "必要に応じて Step 5 の claude 起動をやり直してください。"
+  echo "必要に応じて Step 4 の claude 起動をやり直してください。"
 fi
 
 SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
@@ -166,20 +139,17 @@ SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
 - `TARGET` は固定値（`0.0`）を使わず tmux 実値で解決する
 - `base-index` / `pane-base-index` が `1` の環境でも同じ手順で動作する
 
-### ステップ 7: 計画書を送信して Agent Team 実行を開始
+### ステップ 6: 計画書を送信して Agent Team 実行を開始
 
 送信スクリプトは、本文貼り付け後に 2 通目の Enter を自動送信する。
 
 ```bash
 REPO_ROOT="$(pwd)"
 REQUEST_FILE="$(mktemp)"
-COMMIT_NOTICE=""
-if [ "$FLOW_MODE" = "git" ]; then
-  COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
-fi
+COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 
 cat >| "$REQUEST_FILE" <<EOF
-Agent Team を作成して、以下の計画書に従って実装を開始してください。
+Agent Team を作成して、Issue #{issue_number} の対応を開始してください。以下の計画書に従って実装してください。
 報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
 ${COMMIT_NOTICE}
 
@@ -193,13 +163,13 @@ ${COMMIT_NOTICE}
 - 残課題
 
 完了時は以下コマンドを実行して macOS 通知を送ってください。
-osascript -e 'display notification "Agent Team 実装が完了しました" with title "agent-team-flow" sound name "default"'
+osascript -e 'display notification "Agent Team Issue 実装が完了しました" with title "workflow-agent-team-issue" sound name "default"'
 EOF
 bash "$SEND_SCRIPT" --target "$TARGET" --file "$REQUEST_FILE"
 rm -f "$REQUEST_FILE"
 ```
 
-### ステップ 8: macOS 通知を待機
+### ステップ 7: macOS 通知を待機
 
 - Agent Team 側の処理が完了すると通知が届く想定
 - 進捗確認が必要な場合は tmux 出力を確認
@@ -217,22 +187,10 @@ Agent Team が計画書を分解して実装を進める。呼び出し元は待
 
 ### ステップ 1: 変更内容を確認
 
-git モード:
-
 ```bash
 git status --short --branch
 git diff
 git diff --cached
-```
-
-no-git モード:
-
-- Agent Team の最終報告（実装サマリー・変更ファイル・テスト結果・残課題）を確認
-- 必要に応じて以下で tmux 出力を再確認
-
-```bash
-CAPTURE_TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || tmux list-panes -t "$SESSION" -F '#{session_name}:#{window_index}.#{pane_index}' | head -n 1)"
-tmux capture-pane -pt "$CAPTURE_TARGET" | tail -n 200
 ```
 
 ### ステップ 2: ユーザー承認を取得（必須）
@@ -242,7 +200,7 @@ tmux capture-pane -pt "$CAPTURE_TARGET" | tail -n 200
 ```text
 question: "実装内容を承認しますか？"
 options:
-  - OK（承認）: クリーンアップして完了
+  - OK（承認）: PR 作成まで進む
   - NG（修正依頼）: 修正内容を送って再実行
   - 保留: 手動確認後に再開
 ```
@@ -261,47 +219,59 @@ rm -f "$TERMINAL_STATE_FILE"
 
 2. セキュリティチェック
 
-git モード:
-
 ```bash
 git status  # .env*, *.pem, credentials.json を検出したら警告
 ```
 
-no-git モード:
+3. Issue のチェックボックスを完了に更新
 
 ```bash
-find . -maxdepth 3 \( -name ".env*" -o -name "*.pem" -o -name "credentials.json" \)
+gh issue edit {issue_number} --body "$(gh issue view {issue_number} --json body -q '.body' | sed 's/- \[ \]/- [x]/g')"
 ```
 
-3. 完了出力
+4. コミットと push
 
-git モード:
-
-```text
-## 実装完了
-
-### 推奨コミットメッセージ
-{Conventional Commits 形式}
-
-### 次のステップ（手動）
-1. git add .
-2. git commit -m "{メッセージ}"
-3. git push origin feature/{slug}
-4. 必要に応じて gh pr create
+```bash
+git add .
+git commit -m "{conventional_commit_message}"
+git push origin feature/{issue_number}
 ```
 
-no-git モード:
+5. PR 作成
+
+```bash
+gh pr create --title "{pr_title}" --body "{pr_body}"
+```
+
+PR 本文テンプレート:
+
+```markdown
+## 概要
+{変更内容}
+
+## 並列実行サマリー
+| チームメイト | タスク | 状態 |
+|-------------|--------|------|
+| worker-1 | Task 1 | ✅ 完了 |
+
+## 関連 Issue
+Closes #{issue_number}
+
+## テスト計画
+- [ ] {test_item}
+```
+
+6. 完了報告
 
 ```text
-## 実装完了（no-git モード）
+## 開発フロー完了
 
-### 実装サマリー
-- 変更ファイル: {agent_team_files}
-- テスト結果: {agent_team_tests}
-- 残課題: {agent_team_todos}
+### 作成された Issue
+- #{issue_number}: {issue_title}
 
-### 次のステップ
-- 必要に応じてユーザー環境の手順に沿って成果物を反映
+### 作成された PR
+- PR #{pr_number}: {pr_title}
+- URL: {pr_url}
 ```
 
 ### NG（修正依頼）の場合
@@ -312,10 +282,7 @@ no-git モード:
 USER_FEEDBACK="{user_feedback}"
 REPO_ROOT="$(pwd)"
 FIX_FILE="$(mktemp)"
-COMMIT_NOTICE=""
-if [ "$FLOW_MODE" = "git" ]; then
-  COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
-fi
+COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 
 cat >| "$FIX_FILE" <<EOF
 Agent Team を作成して、以下の修正指示に従って実装を開始してください。
@@ -326,7 +293,7 @@ ${COMMIT_NOTICE}
 
 上記を反映し、完了時は実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
 完了時は以下コマンドを実行して macOS 通知を送ってください。
-osascript -e 'display notification "Agent Team 修正対応が完了しました" with title "agent-team-flow" sound name "default"'
+osascript -e 'display notification "Agent Team Issue 修正対応が完了しました" with title "workflow-agent-team-issue" sound name "default"'
 EOF
 bash "$SEND_SCRIPT" --target "$TARGET" --file "$FIX_FILE"
 rm -f "$FIX_FILE"
@@ -352,6 +319,7 @@ rm -f "$HOLD_FILE"
 
 ## 失敗時の対応
 
+- `gh` 認証失敗: `gh auth login` 実施後に再開
 - `claude` 未インストール: インストール後に再実行
 - `tmux` 未インストール: `tmux` 導入後に再実行
 - Agent Team 側で部分失敗: 失敗タスクのみを再指示してループ

--- a/plugins/shiiman-workflow/skills/workflow-agent-team/SKILL.md
+++ b/plugins/shiiman-workflow/skills/workflow-agent-team/SKILL.md
@@ -1,39 +1,41 @@
 ---
-name: agent-team-issue-flow
-description: Agent Team で Issue から PR まで並列実行する開発フロー。「agent-team-issue-flow」「エージェントチーム Issue フロー」「チーム Issue 開発」「Agent Team Issue」「Issue から並列実装」「チームで PR 作成」「Agent Team で Issue 対応」などで起動。multi-issue-flow の MCP 使用部分を Agent Team に置き換えて実行。
+name: workflow-agent-team
+description: Agent Team で Issue/PR なしの並列実装を実行する軽量フロー。「workflow-agent-team」「エージェントチームフロー」「チーム並列実装」「Agent Team で実装」「チーム軽量フロー」「並列チーム開発」「Agent Team 軽量」などで起動。workflow-multi の MCP 使用部分を Agent Team に置き換えて実行。
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, EnterPlanMode, TodoWrite]
 context: fork
 user-invocable: true
-argument-hint: "[タスク説明] [--plan|--help]"
+argument-hint: "[タスク説明] [--plan|--no-git|--help]"
 ---
 
-# Agent Team Issue Flow
+# Agent Team Flow
 
-Agent Team で Issue 作成から PR 作成までを並列実行するフロー。
-`multi-issue-flow` のうち MCP 依存部分を Agent Team 実行に置き換えます。
+Agent Team で Issue/PR なしに並列実装を進める軽量フロー。
+`workflow-multi` のうち MCP 依存部分を Agent Team 実行に置き換えます。
 
 ## Help
 
 `$ARGUMENTS` に `--help` が含まれる場合、以下を表示して終了:
 
 ```text
-/agent-team-issue-flow - Agent Team Issue 開発フロー
+/workflow-agent-team - Agent Team 軽量フロー
 
 概要:
-  Agent Team で Issue 作成から PR 作成まで並列実行する。
-  Issue 作成 → tmux + Claude 起動 → Agent Team 並列実行 → コミット → PR 作成。
+  Agent Team で Issue/PR なしに並列実装を実行する。
+  ブランチ作成 → tmux + Claude 起動 → Agent Team 並列実行 → コミットメッセージ出力。
 
 使用方法:
-  /agent-team-issue-flow [タスク説明] [オプション]
+  /workflow-agent-team [タスク説明] [オプション]
 
 オプション:
-  --plan  plan mode で計画書を新規作成してから実行
-  --help  このヘルプを表示
+  --plan    plan mode で計画書を新規作成してから実行
+  --no-git  git を使わず no-git モードで実行
+  --help    このヘルプを表示
 
 例:
-  /agent-team-issue-flow                        # 既存計画書から実行
-  /agent-team-issue-flow --plan                 # 計画書を作成してから実行
-  /agent-team-issue-flow "認証機能を並列実装"    # タスク説明から直接実行
+  /workflow-agent-team                        # 既存計画書から実行
+  /workflow-agent-team --plan                 # 計画書を作成してから実行
+  /workflow-agent-team "API リファクタリング"  # タスク説明から直接実行
+  /workflow-agent-team --no-git               # git なしモードで実行
 ```
 
 ## 前提条件
@@ -41,42 +43,66 @@ Agent Team で Issue 作成から PR 作成までを並列実行するフロー�
 - `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` が設定済み（必須）
 - `claude` コマンドが利用可能
 - `tmux` が利用可能
+- `gh` コマンドが利用可能
 - `gh auth status` が成功する（GitHub CLI 認証済み）
 - macOS で `Ghostty` または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
+
+## 実行モード判定（重要）
+
+優先順位は以下。
+
+1. `--no-git` 指定あり: 常に no-git モード
+2. `--no-git` 指定なし + `git rev-parse --is-inside-work-tree` 成功: git モード
+3. それ以外: no-git モード
+
+判定コマンド:
+
+```bash
+git rev-parse --is-inside-work-tree >/dev/null 2>&1
+```
+
+## セッション名 / slug ルール
+
+- slug はタスク内容から簡潔な英語キーワードで作成
+- slug を生成できない場合は `no-git-task` を使用
+- tmux セッション名は `agent-team-{slug}` を使用
 
 ## 実行フロー
 
 ```text
-Phase 1: Issue 作成 → ブランチ作成 → ターミナル + tmux 起動 → claude 起動 → 計画書送信
+git モード:
+Phase 1: ブランチ作成 → ターミナル + tmux 起動 → claude 起動 → 計画書送信
 Phase 2-4: Agent Team が計画書を読み取り自律実装
-Phase 5: 結果確認 → 承認/修正依頼 → クリーンアップ → Issue 更新 → コミット/Push → PR 作成
+Phase 5: 結果確認 → 承認/修正依頼 → クリーンアップ → コミットメッセージ出力
+
+no-git モード:
+Phase 1: ターミナル + tmux 起動 → claude 起動 → 計画書送信
+Phase 2-4: Agent Team が計画書を読み取り自律実装
+Phase 5: 結果確認（Agent Team 報告）→ 承認/修正依頼 → クリーンアップ
 ```
 
-## Phase 1: Issue 作成と Agent Team 起動
+## Phase 1: セットアップと Agent Team 起動
 
-### ステップ 1: Issue 作成
+### ステップ 1: 実行モード判定
 
 ```bash
-gh repo view --json owner,name
-gh issue create --title "{title}" --body "{body}" --label "{label}"
+if [ "{no_git_flag}" = "true" ]; then
+  FLOW_MODE="no-git"
+elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  FLOW_MODE="git"
+else
+  FLOW_MODE="no-git"
+fi
 ```
 
-Issue 本文テンプレート:
+### ステップ 2: slug を決定
 
-```markdown
-## 概要
-{目的・背景}
-
-## タスク一覧
-- [ ] Task 1: {subtask}
-- [ ] Task 2: {subtask}
-
-## 完了条件
-- 全 Task が完了
-- テスト通過
+```text
+slug = {task_slug}
+if slug が空なら slug = "no-git-task"
 ```
 
-### ステップ 2: ブランチ作成
+### ステップ 3: git モード時のみブランチ作成
 
 ```bash
 DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')"
@@ -88,15 +114,16 @@ fi
 git fetch origin "$DEFAULT_BRANCH"
 git checkout "$DEFAULT_BRANCH"
 git pull origin "$DEFAULT_BRANCH"
-git checkout -b feature/{issue_number}
+git checkout -b feature/{slug}
 ```
 
+no-git モードではこのステップをスキップする。
 ユーザーがベースブランチを明示した場合は、そちらを優先する。
 
-### ステップ 3: 共通スクリプトで tmux セッションを起動
+### ステップ 4: 共通スクリプトで tmux セッションを起動
 
 ```bash
-SESSION="agent-team-issue-{issue_number}"
+SESSION="agent-team-{slug}"
 REPO_ROOT="$(pwd)"
 OPEN_TMUX_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/open_tmux_terminal.sh"
 CLEANUP_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/cleanup_tmux_terminal.sh"
@@ -109,13 +136,13 @@ bash "$OPEN_TMUX_SCRIPT" \
   --state-file "$TERMINAL_STATE_FILE"
 ```
 
-### ステップ 4: tmux 内で Claude Code を起動
+### ステップ 5: tmux 内で Claude Code を起動
 
 ```bash
 claude --dangerously-skip-permissions
 ```
 
-### ステップ 5: 送信スクリプトを設定（multi-agent-mcp の送信方式）
+### ステップ 6: 送信スクリプトを設定（multi-agent-mcp の送信方式）
 
 ```bash
 TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || true)"
@@ -130,7 +157,7 @@ fi
 PANE_CMD="$(tmux display-message -p -t "$TARGET" '#{pane_current_command}' 2>/dev/null || true)"
 if [ "$PANE_CMD" != "claude" ]; then
   echo "WARN: target pane is not claude (target: $TARGET, current: ${PANE_CMD:-unknown})"
-  echo "必要に応じて Step 4 の claude 起動をやり直してください。"
+  echo "必要に応じて Step 5 の claude 起動をやり直してください。"
 fi
 
 SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
@@ -139,17 +166,20 @@ SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
 - `TARGET` は固定値（`0.0`）を使わず tmux 実値で解決する
 - `base-index` / `pane-base-index` が `1` の環境でも同じ手順で動作する
 
-### ステップ 6: 計画書を送信して Agent Team 実行を開始
+### ステップ 7: 計画書を送信して Agent Team 実行を開始
 
 送信スクリプトは、本文貼り付け後に 2 通目の Enter を自動送信する。
 
 ```bash
 REPO_ROOT="$(pwd)"
 REQUEST_FILE="$(mktemp)"
-COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+COMMIT_NOTICE=""
+if [ "$FLOW_MODE" = "git" ]; then
+  COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+fi
 
 cat >| "$REQUEST_FILE" <<EOF
-Agent Team を作成して、Issue #{issue_number} の対応を開始してください。以下の計画書に従って実装してください。
+Agent Team を作成して、以下の計画書に従って実装を開始してください。
 報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
 ${COMMIT_NOTICE}
 
@@ -163,13 +193,13 @@ ${COMMIT_NOTICE}
 - 残課題
 
 完了時は以下コマンドを実行して macOS 通知を送ってください。
-osascript -e 'display notification "Agent Team Issue 実装が完了しました" with title "agent-team-issue-flow" sound name "default"'
+osascript -e 'display notification "Agent Team 実装が完了しました" with title "workflow-agent-team" sound name "default"'
 EOF
 bash "$SEND_SCRIPT" --target "$TARGET" --file "$REQUEST_FILE"
 rm -f "$REQUEST_FILE"
 ```
 
-### ステップ 7: macOS 通知を待機
+### ステップ 8: macOS 通知を待機
 
 - Agent Team 側の処理が完了すると通知が届く想定
 - 進捗確認が必要な場合は tmux 出力を確認
@@ -187,10 +217,22 @@ Agent Team が計画書を分解して実装を進める。呼び出し元は待
 
 ### ステップ 1: 変更内容を確認
 
+git モード:
+
 ```bash
 git status --short --branch
 git diff
 git diff --cached
+```
+
+no-git モード:
+
+- Agent Team の最終報告（実装サマリー・変更ファイル・テスト結果・残課題）を確認
+- 必要に応じて以下で tmux 出力を再確認
+
+```bash
+CAPTURE_TARGET="$(tmux display-message -p -t "$SESSION" '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null || tmux list-panes -t "$SESSION" -F '#{session_name}:#{window_index}.#{pane_index}' | head -n 1)"
+tmux capture-pane -pt "$CAPTURE_TARGET" | tail -n 200
 ```
 
 ### ステップ 2: ユーザー承認を取得（必須）
@@ -200,7 +242,7 @@ git diff --cached
 ```text
 question: "実装内容を承認しますか？"
 options:
-  - OK（承認）: PR 作成まで進む
+  - OK（承認）: クリーンアップして完了
   - NG（修正依頼）: 修正内容を送って再実行
   - 保留: 手動確認後に再開
 ```
@@ -219,59 +261,47 @@ rm -f "$TERMINAL_STATE_FILE"
 
 2. セキュリティチェック
 
+git モード:
+
 ```bash
 git status  # .env*, *.pem, credentials.json を検出したら警告
 ```
 
-3. Issue のチェックボックスを完了に更新
+no-git モード:
 
 ```bash
-gh issue edit {issue_number} --body "$(gh issue view {issue_number} --json body -q '.body' | sed 's/- \[ \]/- [x]/g')"
+find . -maxdepth 3 \( -name ".env*" -o -name "*.pem" -o -name "credentials.json" \)
 ```
 
-4. コミットと push
+3. 完了出力
 
-```bash
-git add .
-git commit -m "{conventional_commit_message}"
-git push origin feature/{issue_number}
-```
-
-5. PR 作成
-
-```bash
-gh pr create --title "{pr_title}" --body "{pr_body}"
-```
-
-PR 本文テンプレート:
-
-```markdown
-## 概要
-{変更内容}
-
-## 並列実行サマリー
-| チームメイト | タスク | 状態 |
-|-------------|--------|------|
-| worker-1 | Task 1 | ✅ 完了 |
-
-## 関連 Issue
-Closes #{issue_number}
-
-## テスト計画
-- [ ] {test_item}
-```
-
-6. 完了報告
+git モード:
 
 ```text
-## 開発フロー完了
+## 実装完了
 
-### 作成された Issue
-- #{issue_number}: {issue_title}
+### 推奨コミットメッセージ
+{Conventional Commits 形式}
 
-### 作成された PR
-- PR #{pr_number}: {pr_title}
-- URL: {pr_url}
+### 次のステップ（手動）
+1. git add .
+2. git commit -m "{メッセージ}"
+3. git push origin feature/{slug}
+4. 必要に応じて gh pr create
+```
+
+no-git モード:
+
+```text
+## 実装完了（no-git モード）
+
+### 実装サマリー
+- 変更ファイル: {agent_team_files}
+- テスト結果: {agent_team_tests}
+- 残課題: {agent_team_todos}
+
+### 次のステップ
+- 必要に応じてユーザー環境の手順に沿って成果物を反映
 ```
 
 ### NG（修正依頼）の場合
@@ -282,7 +312,10 @@ Closes #{issue_number}
 USER_FEEDBACK="{user_feedback}"
 REPO_ROOT="$(pwd)"
 FIX_FILE="$(mktemp)"
-COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+COMMIT_NOTICE=""
+if [ "$FLOW_MODE" = "git" ]; then
+  COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+fi
 
 cat >| "$FIX_FILE" <<EOF
 Agent Team を作成して、以下の修正指示に従って実装を開始してください。
@@ -293,7 +326,7 @@ ${COMMIT_NOTICE}
 
 上記を反映し、完了時は実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
 完了時は以下コマンドを実行して macOS 通知を送ってください。
-osascript -e 'display notification "Agent Team Issue 修正対応が完了しました" with title "agent-team-issue-flow" sound name "default"'
+osascript -e 'display notification "Agent Team 修正対応が完了しました" with title "workflow-agent-team" sound name "default"'
 EOF
 bash "$SEND_SCRIPT" --target "$TARGET" --file "$FIX_FILE"
 rm -f "$FIX_FILE"
@@ -319,7 +352,6 @@ rm -f "$HOLD_FILE"
 
 ## 失敗時の対応
 
-- `gh` 認証失敗: `gh auth login` 実施後に再開
 - `claude` 未インストール: インストール後に再実行
 - `tmux` 未インストール: `tmux` 導入後に再実行
 - Agent Team 側で部分失敗: 失敗タスクのみを再指示してループ

--- a/plugins/shiiman-workflow/skills/workflow-multi-issue/SKILL.md
+++ b/plugins/shiiman-workflow/skills/workflow-multi-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: multi-issue-flow
-description: MCP マルチエージェントで Issue から PR まで並列実行する開発フロー。「マルチ Issue フロー」「multi-issue-flow」「並列 Issue 開発」「マルチエージェント Issue」「複数人で Issue」「並列 Issue フロー」「マルチフロー Issue」などで起動。複数 Worker でタスクを並列実行。
+name: workflow-multi-issue
+description: MCP マルチエージェントで Issue から PR まで並列実行する開発フロー。「マルチ Issue フロー」「workflow-multi-issue」「並列 Issue 開発」「マルチエージェント Issue」「複数人で Issue」「並列 Issue フロー」「マルチフロー Issue」などで起動。複数 Worker でタスクを並列実行。
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, EnterPlanMode, TodoWrite, Task]
 context: fork
 user-invocable: true
@@ -16,23 +16,23 @@ MCP マルチエージェントで Issue から PR まで並列実行する開�
 `$ARGUMENTS` に `--help` が含まれる場合、以下を表示して終了:
 
 ```text
-/multi-issue-flow - MCP マルチエージェント Issue 開発フロー
+/workflow-multi-issue - MCP マルチエージェント Issue 開発フロー
 
 概要:
   MCP マルチエージェントで Issue 作成から PR 作成まで並列実行する。
   Issue 作成 → MCP 初期化 → Admin/Worker 並列実行 → コミット → PR 作成。
 
 使用方法:
-  /multi-issue-flow [タスク説明] [オプション]
+  /workflow-multi-issue [タスク説明] [オプション]
 
 オプション:
   --plan  plan mode で計画書を新規作成してから実行
   --help  このヘルプを表示
 
 例:
-  /multi-issue-flow                        # 既存計画書から実行
-  /multi-issue-flow --plan                 # 計画書を作成してから実行
-  /multi-issue-flow "認証機能を並列実装"    # タスク説明から直接実行
+  /workflow-multi-issue                        # 既存計画書から実行
+  /workflow-multi-issue --plan                 # 計画書を作成してから実行
+  /workflow-multi-issue "認証機能を並列実装"    # タスク説明から直接実行
 ```
 
 ## 前提条件

--- a/plugins/shiiman-workflow/skills/workflow-multi/SKILL.md
+++ b/plugins/shiiman-workflow/skills/workflow-multi/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: multi-flow
-description: MCP マルチエージェントで Issue/PR なしに並列実行する軽量フロー。「マルチフロー」「multi-flow」「並列軽量フロー」「マルチエージェント実行」「複数人で実行」「並列フロー」「マルチ軽量」などで起動。複数 Worker でタスクを並列実行しコミットメッセージを出力。
+name: workflow-multi
+description: MCP マルチエージェントで Issue/PR なしに並列実行する軽量フロー。「マルチフロー」「workflow-multi」「並列軽量フロー」「マルチエージェント実行」「複数人で実行」「並列フロー」「マルチ軽量」などで起動。複数 Worker でタスクを並列実行しコミットメッセージを出力。
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, EnterPlanMode, TodoWrite, Task]
 context: fork
 user-invocable: true
@@ -16,14 +16,14 @@ MCP マルチエージェントで Issue/PR なしに並列実行する軽量フ
 `$ARGUMENTS` に `--help` が含まれる場合、以下を表示して終了:
 
 ```text
-/multi-flow - MCP マルチエージェント軽量フロー
+/workflow-multi - MCP マルチエージェント軽量フロー
 
 概要:
   MCP マルチエージェントで Issue/PR なしに並列実行する。
   ブランチ作成 → MCP 初期化 → Admin/Worker 並列実行 → コミットメッセージ出力。
 
 使用方法:
-  /multi-flow [タスク説明] [オプション]
+  /workflow-multi [タスク説明] [オプション]
 
 オプション:
   --plan    plan mode で計画書を新規作成してから実行
@@ -31,10 +31,10 @@ MCP マルチエージェントで Issue/PR なしに並列実行する軽量フ
   --help    このヘルプを表示
 
 例:
-  /multi-flow                        # 既存計画書から実行
-  /multi-flow --plan                 # 計画書を作成してから実行
-  /multi-flow "API リファクタリング"  # タスク説明から直接実行
-  /multi-flow --no-git               # git なしモードで実行
+  /workflow-multi                        # 既存計画書から実行
+  /workflow-multi --plan                 # 計画書を作成してから実行
+  /workflow-multi "API リファクタリング"  # タスク説明から直接実行
+  /workflow-multi --no-git               # git なしモードで実行
 ```
 
 ## 前提条件

--- a/plugins/shiiman-workflow/skills/workflow-single-issue/SKILL.md
+++ b/plugins/shiiman-workflow/skills/workflow-single-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: single-issue-flow
-description: Issue 作成から PR 作成まで自動実行するシングルエージェント開発フロー。「シングル Issue フロー」「single-issue-flow」「Issue から PR まで」「Issue ベース開発」「シングルフロー Issue」「1人で Issue 開発」「Issue 付きフロー」などで起動。計画書に基づいた自動実装を実行。
+name: workflow-single-issue
+description: Issue 作成から PR 作成まで自動実行するシングルエージェント開発フロー。「シングル Issue フロー」「workflow-single-issue」「Issue から PR まで」「Issue ベース開発」「シングルフロー Issue」「1人で Issue 開発」「Issue 付きフロー」などで起動。計画書に基づいた自動実装を実行。
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, EnterPlanMode, TodoWrite, Task]
 context: fork
 user-invocable: true
@@ -16,23 +16,23 @@ Issue 作成から PR 作成まで自動実行するシングルエージェン�
 `$ARGUMENTS` に `--help` が含まれる場合、以下を表示して終了:
 
 ```text
-/single-issue-flow - シングルエージェント Issue 開発フロー
+/workflow-single-issue - シングルエージェント Issue 開発フロー
 
 概要:
   Issue 作成から PR 作成まで自動実行する。
   Issue 作成 → ブランチ作成 → 実装 → コミット → PR 作成。
 
 使用方法:
-  /single-issue-flow [タスク説明] [オプション]
+  /workflow-single-issue [タスク説明] [オプション]
 
 オプション:
   --plan  plan mode で計画書を新規作成してから実行
   --help  このヘルプを表示
 
 例:
-  /single-issue-flow                        # 既存計画書から実行
-  /single-issue-flow --plan                 # 計画書を作成してから実行
-  /single-issue-flow "ログイン機能を追加"    # タスク説明から直接実行
+  /workflow-single-issue                        # 既存計画書から実行
+  /workflow-single-issue --plan                 # 計画書を作成してから実行
+  /workflow-single-issue "ログイン機能を追加"    # タスク説明から直接実行
 ```
 
 ## 3つの実行モード
@@ -97,8 +97,8 @@ ls -t ~/.claude/plans/*.md | head -1
 計画書が見つかりませんでした。
 
 ### 代替手段
-- `single-issue-flow --plan` で新しい計画を作成
-- `single-issue-flow タスク説明` で直接実行
+- `workflow-single-issue --plan` で新しい計画を作成
+- `workflow-single-issue タスク説明` で直接実行
 ```
 
 計画書が見つかったら、ステップ 1 から実行。
@@ -110,7 +110,7 @@ ls -t ~/.claude/plans/*.md | head -1
 1. ユーザーに実装したい内容を確認
 2. `EnterPlanMode` を実行して plan mode に入る
 3. 計画書を作成（`.claude/plans/` に保存される）
-4. ユーザーが計画を承認したら、自動的に single-issue-flow の実行フェーズに進む
+4. ユーザーが計画を承認したら、自動的に workflow-single-issue の実行フェーズに進む
 
 ## モード 3: 直接実行モード（タスク説明あり）
 

--- a/plugins/shiiman-workflow/skills/workflow-single/SKILL.md
+++ b/plugins/shiiman-workflow/skills/workflow-single/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: single-flow
-description: Issue/PR なしで計画書からタスクを実行しコミットメッセージを出力する軽量フロー。「シングルフロー」「single-flow」「軽量フロー」「Issue なしフロー」「シンプル実行」「計画書実行」「コミットのみフロー」などで起動。PR を作らない軽量な開発フロー。
+name: workflow-single
+description: Issue/PR なしで計画書からタスクを実行しコミットメッセージを出力する軽量フロー。「シングルフロー」「workflow-single」「軽量フロー」「Issue なしフロー」「シンプル実行」「計画書実行」「コミットのみフロー」などで起動。PR を作らない軽量な開発フロー。
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion, EnterPlanMode, TodoWrite, Task]
 context: fork
 user-invocable: true
@@ -16,23 +16,23 @@ Issue/PR なしで計画書からタスクを実行し、コミットメッセ�
 `$ARGUMENTS` に `--help` が含まれる場合、以下を表示して終了:
 
 ```text
-/single-flow - 軽量シングルエージェントフロー
+/workflow-single - 軽量シングルエージェントフロー
 
 概要:
   Issue/PR なしで計画書からタスクを実行し、コミットメッセージを出力する。
   ブランチ作成 → 実装 → 自己レビュー → コミットメッセージ出力。
 
 使用方法:
-  /single-flow [タスク説明] [オプション]
+  /workflow-single [タスク説明] [オプション]
 
 オプション:
   --plan  plan mode で計画書を新規作成してから実行
   --help  このヘルプを表示
 
 例:
-  /single-flow                        # 既存計画書から実行
-  /single-flow --plan                 # 計画書を作成してから実行
-  /single-flow "ログイン機能を追加"    # タスク説明から直接実行
+  /workflow-single                        # 既存計画書から実行
+  /workflow-single --plan                 # 計画書を作成してから実行
+  /workflow-single "ログイン機能を追加"    # タスク説明から直接実行
 ```
 
 ## 前提条件
@@ -102,8 +102,8 @@ ls -t ~/.claude/plans/*.md | head -1
 計画書が見つかりませんでした。
 
 ### 代替手段
-- `single-flow --plan` で新しい計画を作成
-- `single-flow タスク説明` で直接実行
+- `workflow-single --plan` で新しい計画を作成
+- `workflow-single タスク説明` で直接実行
 ```
 
 計画書が見つかったら、ステップ 1 から実行。
@@ -115,7 +115,7 @@ ls -t ~/.claude/plans/*.md | head -1
 1. ユーザーに実装したい内容を確認
 2. `EnterPlanMode` を実行して plan mode に入る
 3. 計画書を作成（`.claude/plans/` に保存される）
-4. ユーザーが計画を承認したら、自動的に single-flow の実行フェーズに進む
+4. ユーザーが計画を承認したら、自動的に workflow-single の実行フェーズに進む
 
 ## モード 3: 直接実行モード（タスク説明あり）
 


### PR DESCRIPTION
## 概要

shiiman-workflow プラグインの全6スキルを `〇〇-flow` → `workflow-〇〇` にリネーム。

Closes #147

## 変更内容

- **ディレクトリリネーム**: 6スキルディレクトリを `git mv` で移動
- **SKILL.md 更新**: name/description/Help セクション内のスキル名を全て新名に変更
- **ドキュメント更新**: CLAUDE.md、README.md、shiiman-workflow README、shiiman-git README
- **CLAUDE.md**: agent-team 系2スキルを Workflow セクションに追加（元々未記載）
- **バージョン**: 1.8.8 → 2.0.0（MAJOR: 破壊的リネーム）

| 旧スキル名 | 新スキル名 |
|---|---|
| single-flow | workflow-single |
| single-issue-flow | workflow-single-issue |
| multi-flow | workflow-multi |
| multi-issue-flow | workflow-multi-issue |
| agent-team-flow | workflow-agent-team |
| agent-team-issue-flow | workflow-agent-team-issue |

## テスト計画

- [x] `grep -r` で旧スキル名の残存なし
- [x] `claude plugin validate .` パス