### PR TITLE
fix: agent-team/agent-team-issue 計画書・修正依頼をファイル渡し化（#161）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
@@ -146,16 +146,25 @@ SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
 
 ```bash
 REPO_ROOT="$(pwd)"
-REQUEST_FILE="$(mktemp)"
 COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 
+# 計画書をファイルに保存
+TS="$(date +%Y%m%d-%H%M%S)"
+PLAN_FILE="${REPO_ROOT}/.claude/tmp/${TS}-issue-${issue_number}-plan.md"
+mkdir -p "${REPO_ROOT}/.claude/tmp"
+cat >| "$PLAN_FILE" <<EOF
+{plan_or_task}
+EOF
+
+# パス参照のみを送信
+REQUEST_FILE="$(mktemp)"
 cat >| "$REQUEST_FILE" <<EOF
-Agent Team を作成して、Issue #{issue_number} の対応を開始してください。以下の計画書に従って実装してください。
+Agent Team を作成して、Issue #{issue_number} の対応を開始してください。計画書に従って実装してください。
 報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
 ${COMMIT_NOTICE}
 
-計画書:
-{plan_or_task}
+計画書ファイル: ${PLAN_FILE}
+Read ツールで上記ファイルを読み込んでから実装を進めてください。
 
 完了時は以下を報告してください。
 - 実装サマリー
@@ -288,15 +297,25 @@ Closes #{issue_number}
 ```bash
 USER_FEEDBACK="{user_feedback}"
 REPO_ROOT="$(pwd)"
-FIX_FILE="$(mktemp)"
 COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 
+# 修正依頼をファイルに保存
+TS="$(date +%Y%m%d-%H%M%S)"
+FIX_REQUEST_FILE="${REPO_ROOT}/.claude/tmp/${TS}-issue-${issue_number}-fix-request.md"
+mkdir -p "${REPO_ROOT}/.claude/tmp"
+cat >| "$FIX_REQUEST_FILE" <<EOF
+${USER_FEEDBACK}
+EOF
+
+# パス参照のみを送信
+FIX_FILE="$(mktemp)"
 cat >| "$FIX_FILE" <<EOF
-Agent Team を作成して、以下の修正指示に従って実装を開始してください。
+Agent Team を作成して、修正指示に従って実装を開始してください。
 報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
 ${COMMIT_NOTICE}
 
-修正依頼: ${USER_FEEDBACK}
+修正依頼ファイル: ${FIX_REQUEST_FILE}
+Read ツールで上記ファイルを読み込んでから修正を進めてください。
 
 上記を反映し、完了時は実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
 完了時は以下コマンドを実行して macOS 通知を送ってください。

--- a/plugins/shiiman-workflow/skills/agent-team/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team/SKILL.md
@@ -173,19 +173,28 @@ SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
 
 ```bash
 REPO_ROOT="$(pwd)"
-REQUEST_FILE="$(mktemp)"
 COMMIT_NOTICE=""
 if [ "$FLOW_MODE" = "git" ]; then
   COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 fi
 
+# 計画書をファイルに保存
+TS="$(date +%Y%m%d-%H%M%S)"
+PLAN_FILE="${REPO_ROOT}/.claude/tmp/${TS}-${slug}-plan.md"
+mkdir -p "${REPO_ROOT}/.claude/tmp"
+cat >| "$PLAN_FILE" <<EOF
+{plan_or_task}
+EOF
+
+# パス参照のみを送信
+REQUEST_FILE="$(mktemp)"
 cat >| "$REQUEST_FILE" <<EOF
-Agent Team を作成して、以下の計画書に従って実装を開始してください。
+Agent Team を作成して、計画書に従って実装を開始してください。
 報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
 ${COMMIT_NOTICE}
 
-計画書:
-{plan_or_task}
+計画書ファイル: ${PLAN_FILE}
+Read ツールで上記ファイルを読み込んでから実装を進めてください。
 
 完了時は以下を報告してください。
 - 実装サマリー
@@ -314,18 +323,28 @@ no-git モード:
 ```bash
 USER_FEEDBACK="{user_feedback}"
 REPO_ROOT="$(pwd)"
-FIX_FILE="$(mktemp)"
 COMMIT_NOTICE=""
 if [ "$FLOW_MODE" = "git" ]; then
   COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 fi
 
+# 修正依頼をファイルに保存
+TS="$(date +%Y%m%d-%H%M%S)"
+FIX_REQUEST_FILE="${REPO_ROOT}/.claude/tmp/${TS}-${slug}-fix-request.md"
+mkdir -p "${REPO_ROOT}/.claude/tmp"
+cat >| "$FIX_REQUEST_FILE" <<EOF
+${USER_FEEDBACK}
+EOF
+
+# パス参照のみを送信
+FIX_FILE="$(mktemp)"
 cat >| "$FIX_FILE" <<EOF
-Agent Team を作成して、以下の修正指示に従って実装を開始してください。
+Agent Team を作成して、修正指示に従って実装を開始してください。
 報告書などのアウトプットがある場合は "${REPO_ROOT}/.claude/tmp" に出力してください。
 ${COMMIT_NOTICE}
 
-修正依頼: ${USER_FEEDBACK}
+修正依頼ファイル: ${FIX_REQUEST_FILE}
+Read ツールで上記ファイルを読み込んでから修正を進めてください。
 
 上記を反映し、完了時は実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
 完了時は以下コマンドを実行して macOS 通知を送ってください。


### PR DESCRIPTION
## 概要

- agent-team / agent-team-issue で tmux 内 Claude への計画書・修正依頼送信をプロンプト直接埋め込みからファイル渡し方式に変更
- 大きな計画書でも tmux 貼り付けの安定性を確保

## 変更内容

- 計画書・修正依頼を `.claude/tmp/{yyyymmdd-HHmmss}-{識別子}-{plan|fix-request}.md` に保存
- 送信プロンプトにはファイルパスのみを渡し「Read ツールで読め」と指示
- shiiman-workflow 4.0.0 → 4.0.1（PATCH）

## 関連 Issue

Closes #161

## テスト計画

- [x] npm run format:check パス
- [x] 送信プロンプトに計画書の直接埋め込みがないこと
- [x] plugin.json / marketplace.json バージョン一致（4.0.1）