### PR TITLE
fix(shiiman-slack,shiiman-google): SKILL.mdとスクリプトの不整合修正（#163）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,7 +47,7 @@
     {
       "name": "shiiman-google",
       "description": "Google Workspace 操作 - 認証、Drive 検索、Docs/Sheets/Slides/Forms/Apps Script 編集、Calendar、Gmail 未読管理を提供",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "source": "./plugins/shiiman-google",
       "category": "productivity"
     },
@@ -68,7 +68,7 @@
     {
       "name": "shiiman-slack",
       "description": "Slack 通知管理 - 未読確認、既読化、メンション確認・返信、プロフィール更新を提供",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "source": "./plugins/shiiman-slack",
       "category": "productivity"
     }

--- a/plugins/shiiman-google/.claude-plugin/plugin.json
+++ b/plugins/shiiman-google/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-google",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Google Workspace 操作 - 認証、Drive 検索、Docs/Sheets/Slides/Forms/Apps Script 編集、Calendar、Gmail 未読管理を提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-google/scripts/google_apps_script.py
+++ b/plugins/shiiman-google/scripts/google_apps_script.py
@@ -188,6 +188,7 @@ def main():
     parser = argparse.ArgumentParser(description="Google Apps Script 操作")
     parser.add_argument("--format", choices=["table", "json"], default="table", help="出力形式")
     parser.add_argument("--token", help="トークンファイルパス（省略時はアクティブプロファイル）")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
 
     subparsers = parser.add_subparsers(dest="command", help="サブコマンド")
 
@@ -213,7 +214,12 @@ def main():
         sys.exit(1)
 
     # トークンパス決定
-    token_path = args.token if args.token else get_token_path()
+    if args.token:
+        token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
+    else:
+        token_path = get_token_path()
     if not token_path:
         print_error("アクティブなプロファイルがありません。'google_auth.py login' で認証してください。")
         sys.exit(1)

--- a/plugins/shiiman-google/scripts/google_calendar.py
+++ b/plugins/shiiman-google/scripts/google_calendar.py
@@ -682,6 +682,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Google Calendar 操作ツール")
     parser.add_argument("--token", help="トークンファイルパス")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
     parser.add_argument(
         "--format",
         choices=["table", "json"],
@@ -779,6 +780,8 @@ def main() -> None:
     # トークンパスの決定
     if args.token:
         token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
     else:
         token_path = get_token_path()
 

--- a/plugins/shiiman-google/scripts/google_docs.py
+++ b/plugins/shiiman-google/scripts/google_docs.py
@@ -256,6 +256,7 @@ def main():
     parser = argparse.ArgumentParser(description="Google Docs 操作")
     parser.add_argument("--format", choices=["table", "json"], default="table", help="出力形式")
     parser.add_argument("--token", help="トークンファイルパス（省略時はアクティブプロファイル）")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
 
     subparsers = parser.add_subparsers(dest="command", help="サブコマンド")
 
@@ -293,7 +294,12 @@ def main():
         sys.exit(1)
 
     # トークンパス決定
-    token_path = args.token if args.token else get_token_path()
+    if args.token:
+        token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
+    else:
+        token_path = get_token_path()
     if not token_path:
         print_error("アクティブなプロファイルがありません。'google_auth.py login' で認証してください。")
         sys.exit(1)

--- a/plugins/shiiman-google/scripts/google_drive.py
+++ b/plugins/shiiman-google/scripts/google_drive.py
@@ -417,6 +417,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Google Drive 操作ツール")
     parser.add_argument("--token", help="トークンファイルパス")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
     parser.add_argument(
         "--format",
         choices=["table", "json"],
@@ -505,6 +506,8 @@ def main() -> None:
     # トークンパスの決定
     if args.token:
         token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
     else:
         token_path = get_token_path()
 

--- a/plugins/shiiman-google/scripts/google_forms.py
+++ b/plugins/shiiman-google/scripts/google_forms.py
@@ -300,6 +300,7 @@ def main():
     parser = argparse.ArgumentParser(description="Google Forms 操作")
     parser.add_argument("--format", choices=["table", "json"], default="table", help="出力形式")
     parser.add_argument("--token", help="トークンファイルパス（省略時はアクティブプロファイル）")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
 
     subparsers = parser.add_subparsers(dest="command", help="サブコマンド")
 
@@ -334,7 +335,12 @@ def main():
         sys.exit(1)
 
     # トークンパス決定
-    token_path = args.token if args.token else get_token_path()
+    if args.token:
+        token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
+    else:
+        token_path = get_token_path()
     if not token_path:
         print_error("アクティブなプロファイルがありません。'google_auth.py login' で認証してください。")
         sys.exit(1)

--- a/plugins/shiiman-google/scripts/google_gmail.py
+++ b/plugins/shiiman-google/scripts/google_gmail.py
@@ -447,6 +447,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Gmail 操作ツール")
     parser.add_argument("--token", help="トークンファイルパス")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
     parser.add_argument(
         "--format",
         choices=["table", "json"],
@@ -521,6 +522,8 @@ def main() -> None:
     # トークンパスの決定
     if args.token:
         token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
     else:
         token_path = get_token_path()
 

--- a/plugins/shiiman-google/scripts/google_sheets.py
+++ b/plugins/shiiman-google/scripts/google_sheets.py
@@ -424,6 +424,7 @@ def main():
     parser = argparse.ArgumentParser(description="Google Sheets 操作")
     parser.add_argument("--format", choices=["table", "json"], default="table", help="出力形式")
     parser.add_argument("--token", help="トークンファイルパス（省略時はアクティブプロファイル）")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
 
     subparsers = parser.add_subparsers(dest="command", help="サブコマンド")
 
@@ -475,7 +476,12 @@ def main():
         sys.exit(1)
 
     # トークンパス決定
-    token_path = args.token if args.token else get_token_path()
+    if args.token:
+        token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
+    else:
+        token_path = get_token_path()
     if not token_path:
         print_error("アクティブなプロファイルがありません。'google_auth.py login' で認証してください。")
         sys.exit(1)

--- a/plugins/shiiman-google/scripts/google_slides.py
+++ b/plugins/shiiman-google/scripts/google_slides.py
@@ -277,6 +277,7 @@ def main():
     parser = argparse.ArgumentParser(description="Google Slides 操作")
     parser.add_argument("--format", choices=["table", "json"], default="table", help="出力形式")
     parser.add_argument("--token", help="トークンファイルパス（省略時はアクティブプロファイル）")
+    parser.add_argument("--profile", help="認証プロファイル名（デフォルト: アクティブプロファイル）")
 
     subparsers = parser.add_subparsers(dest="command", help="サブコマンド")
 
@@ -316,7 +317,12 @@ def main():
         sys.exit(1)
 
     # トークンパス決定
-    token_path = args.token if args.token else get_token_path()
+    if args.token:
+        token_path = args.token
+    elif args.profile:
+        token_path = get_token_path(args.profile)
+    else:
+        token_path = get_token_path()
     if not token_path:
         print_error("アクティブなプロファイルがありません。'google_auth.py login' で認証してください。")
         sys.exit(1)

--- a/plugins/shiiman-google/skills/drive-search/SKILL.md
+++ b/plugins/shiiman-google/skills/drive-search/SKILL.md
@@ -41,7 +41,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/google_drive.py search --query "name contai
 ### プロファイル指定で検索
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/scripts/google_drive.py search --profile <profile-name> --query "name contains '<検索キーワード>'"
+python ${CLAUDE_PLUGIN_ROOT}/scripts/google_drive.py --profile <profile-name> search --query "name contains '<検索キーワード>'"
 ```
 
 ## 検索クエリ例

--- a/plugins/shiiman-google/skills/gmail-unread-mark/SKILL.md
+++ b/plugins/shiiman-google/skills/gmail-unread-mark/SKILL.md
@@ -37,7 +37,7 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/google_gmail.py mark-read --ids <message-id
 ### 複数メッセージを一括で既読化
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/scripts/google_gmail.py mark-read --ids <id1>,<id2>,<id3>
+python ${CLAUDE_PLUGIN_ROOT}/scripts/google_gmail.py mark-read --ids <id1> <id2> <id3>
 ```
 
 ### 未読メッセージを一括で既読化
@@ -49,12 +49,12 @@ python ${CLAUDE_PLUGIN_ROOT}/scripts/google_gmail.py mark-read --all
 ### プロファイル指定
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/scripts/google_gmail.py mark-read --profile <profile-name> --all
+python ${CLAUDE_PLUGIN_ROOT}/scripts/google_gmail.py --profile <profile-name> mark-read --all
 ```
 
 ## オプション
 
-- `--ids <id1,id2,...>`: 既読化するメッセージIDのリスト
+- `--ids <id1> <id2> ...`: 既読化するメッセージIDのリスト（スペース区切り）
 - `--all`: 全ての未読メッセージを既読化
 
 ## 関連操作

--- a/plugins/shiiman-slack/.claude-plugin/plugin.json
+++ b/plugins/shiiman-slack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-slack",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Slack 通知管理 - 未読確認、既読化、メンション確認・返信、プロフィール更新を提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-slack/skills/mention-check/SKILL.md
+++ b/plugins/shiiman-slack/skills/mention-check/SKILL.md
@@ -45,9 +45,8 @@ Slack で自分へのメンションを確認します。
 
 ```bash
 # Pythonスクリプトでメンション取得
-python ${CLAUDE_PLUGIN_ROOT}/scripts/slack_message.py mentions \
-  --max 20 \
-  --format table
+python ${CLAUDE_PLUGIN_ROOT}/scripts/slack_message.py --format table mentions \
+  --max 20
 ```
 
 ## 出力例

--- a/plugins/shiiman-slack/skills/unread-check/SKILL.md
+++ b/plugins/shiiman-slack/skills/unread-check/SKILL.md
@@ -33,14 +33,15 @@ Slack の未読メッセージを確認します。
 Pythonスクリプトで未読メッセージ一覧を取得:
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/scripts/slack_message.py unread \
-  --format table
+python ${CLAUDE_PLUGIN_ROOT}/scripts/slack_message.py --format table unread \
+  --channel <CHANNEL_ID>
 ```
 
 オプション:
 
+- `--channel <CHANNEL_ID>`: チャンネルID（必須）
 - `--max <number>`: 最大取得件数（デフォルト: 20）
-- `--format <table|json>`: 出力形式（デフォルト: table）
+- `--format <table|json>`: 出力形式（デフォルト: table）※サブコマンドの前に指定
 
 ### 2. 結果の整形
 


### PR DESCRIPTION
## 概要

shiiman-slack と shiiman-google プラグインにおいて、SKILL.md に記載されたコマンド例・引数仕様がスクリプトの実際の argparse 定義と一致しない不整合を修正。

## 変更内容

### shiiman-slack（SKILL.md 修正）
- mention-check: `--format table` をサブコマンド前に移動（argparse エラー修正）
- unread-check: `--format table` をサブコマンド前に移動 + `--channel` 必須パラメータを追記

### shiiman-google（SKILL.md 修正）
- gmail-unread-mark: `--ids` をカンマ区切りからスペース区切りに修正（`nargs="+"` 対応）
- gmail-unread-mark / drive-search: `--profile` をサブコマンド前に移動（親パーサー引数のため）

### shiiman-google（Python スクリプト修正）
- 全8スクリプトの親パーサーに `--profile` オプションを追加
  - google_gmail.py, google_drive.py, google_calendar.py, google_sheets.py
  - google_slides.py, google_forms.py, google_docs.py, google_apps_script.py
- トークンパス決定ロジックを `--token` > `--profile` > アクティブプロファイルの優先順位に更新

### バージョン更新
- shiiman-slack: 4.0.0 → 4.0.1（PATCH: バグ修正）
- shiiman-google: 3.0.0 → 3.1.0（MINOR: `--profile` 新機能追加）

## 関連 Issue

Closes #163

## テスト計画

- [ ] 各スクリプトの `--help` で `--profile` オプションが表示されることを確認
- [ ] SKILL.md のコマンド例と argparse 定義の照合
- [ ] `npm run format:check` がパスすることを確認

## チェックリスト

- [x] 命名規則に従っている
- [x] 動作確認済み（Prettier フォーマットチェック通過）
- [x] バージョン更新済み（plugin.json + marketplace.json）