### PR TITLE
fix(shiiman-claude): plugin-update手順をmarketplace git pull+install方式に修正（#167）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "shiiman-claude",
       "description": "Claude Code プロジェクト設定管理 - MCP サーバー管理、Claude 設定管理、Claude リソース一覧表示、Claude Code CLI 更新を提供",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "source": "./plugins/shiiman-claude",
       "category": "utility"
     },

--- a/plugins/shiiman-claude/.claude-plugin/plugin.json
+++ b/plugins/shiiman-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-claude",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Claude Code プロジェクト設定管理 - MCP サーバー管理、Claude 設定管理、Claude リソース一覧表示、Claude Code CLI 更新を提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-claude/skills/update/SKILL.md
+++ b/plugins/shiiman-claude/skills/update/SKILL.md
@@ -68,11 +68,35 @@ Claude Code CLI のバージョン確認と更新を行います。
 
 #### plugin-update
 
-1. `claude plugin list` でインストール済みプラグイン一覧を取得
-2. 各プラグインの現在のバージョンを記録
-3. 実行前にユーザー確認を行う
-4. 各プラグインに対して `claude plugin update <name>` を実行
-5. 更新前後のバージョンを比較して結果を報告
+1. marketplace キャッシュを最新化:
+
+```bash
+# known_marketplaces.json から marketplace 一覧と installLocation を取得
+cat ~/.claude/plugins/known_marketplaces.json
+```
+
+各 marketplace の `installLocation` で `git pull` を実行:
+
+```bash
+git -C <installLocation> pull 2>&1
+```
+
+2. `~/.claude/settings.json` の `enabledPlugins` から有効プラグイン一覧を取得:
+
+```bash
+cat ~/.claude/settings.json
+```
+
+`enabledPlugins` のキーは `<plugin>@<marketplace>` 形式。値が `true` のもののみ対象。
+
+3. 各プラグインの更新前バージョンを記録:
+
+`~/.claude/plugins/cache/<marketplace>/<plugin>/` 配下のバージョンディレクトリ名から現在のバージョンを特定（最も新しいもの）。
+
+4. 実行前にユーザー確認を行う
+5. 各プラグインに対して `claude plugin install <plugin>@<marketplace>` を実行
+6. 更新後のバージョンを確認し、更新前後のバージョンを比較して結果を報告
+7. 更新があった場合「Claude CLI を再起動すると反映されます」と案内
 
 ## 出力フォーマット
 


### PR DESCRIPTION
## 概要

- `shiiman-claude:update` の `plugin-update` 手順が実際の動作と一致していなかったのを修正
- `claude plugin update` は marketplace キャッシュが古いと最新バージョンを取得しないため、git pull + install 方式に変更

## 変更内容

- SKILL.md の plugin-update セクションを正しい手順に書き換え
- plugin.json バージョンを 2.0.0 → 2.0.1 に更新
- marketplace.json バージョンを 2.0.1 に同期

## 関連 Issue

Closes #167

## テスト計画

- [ ] `/shiiman-claude:update plugin-update` を実行し、marketplace の git pull → install が正しく動作することを確認