### PR TITLE
fix(shiiman-slack): SKILL.mdの誤ったSLACK_BOT_TOKEN参照をuser-setupに統一（#169）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,7 +68,7 @@
     {
       "name": "shiiman-slack",
       "description": "Slack 通知管理 - 未読確認、既読化、メンション確認・返信、プロフィール更新を提供",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "source": "./plugins/shiiman-slack",
       "category": "productivity"
     }

--- a/plugins/shiiman-slack/.claude-plugin/plugin.json
+++ b/plugins/shiiman-slack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-slack",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Slack 通知管理 - 未読確認、既読化、メンション確認・返信、プロフィール更新を提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-slack/skills/mention-check/SKILL.md
+++ b/plugins/shiiman-slack/skills/mention-check/SKILL.md
@@ -71,11 +71,9 @@ marketing       鈴木次郎    @you 新しい企画について相談したい�
 - **パーマリンク**: 各メンションへの直接リンクを表示
 - **チャンネル名**: メンションがあったチャンネルを表示
 
-## 必要な環境変数
+## トークン設定
 
-```bash
-export SLACK_BOT_TOKEN="xoxb-your-bot-token"
-```
+`/shiiman-slack:user-setup` でトークンを設定してください。
 
 ## 必要なスコープ
 

--- a/plugins/shiiman-slack/skills/mention-reply/SKILL.md
+++ b/plugins/shiiman-slack/skills/mention-reply/SKILL.md
@@ -89,21 +89,7 @@ python ${CLAUDE_PLUGIN_ROOT}/skills/mention-reply/scripts/slack_thread.py reply 
 | `--thread-ts`, `-t` | Yes  | スレッドのタイムスタンプ |
 | `--text`, `-m`      | Yes  | 返信テキスト             |
 
-## User Token の設定方法
+## トークン設定
 
-ユーザーとして返信するには、`.claude/settings.local.json` に `SLACK_USER_TOKEN` を設定:
-
-```json
-{
-  "mcpServers": {
-    "slack": {
-      "env": {
-        "SLACK_BOT_TOKEN": "xoxb-your-bot-token",
-        "SLACK_USER_TOKEN": "xoxp-your-user-token"
-      }
-    }
-  }
-}
-```
-
+`/shiiman-slack:user-setup` でトークンを設定してください。
 User Token には `chat:write` スコープが必要です。

--- a/plugins/shiiman-slack/skills/profile-update/SKILL.md
+++ b/plugins/shiiman-slack/skills/profile-update/SKILL.md
@@ -33,20 +33,7 @@ User Token がない場合はエラーになります。
 
 ### User Token の設定
 
-`.claude/settings.local.json` または環境変数で設定：
-
-```json
-{
-  "mcpServers": {
-    "slack": {
-      "env": {
-        "SLACK_BOT_TOKEN": "xoxb-your-bot-token",
-        "SLACK_USER_TOKEN": "xoxp-your-user-token"
-      }
-    }
-  }
-}
-```
+`/shiiman-slack:user-setup` でトークンを設定してください。
 
 ### 必要なスコープ
 


### PR DESCRIPTION
## 概要

- shiiman-slack の3つの SKILL.md に残っていた誤った `SLACK_BOT_TOKEN` 環境変数の記述を `/shiiman-slack:user-setup` 参照に統一
- 実際のトークン管理は `~/.config/shiiman-slack/config.json` で行っている

## 変更内容

- `mention-check/SKILL.md` - `## 必要な環境変数` → `## トークン設定`（user-setup 参照）
- `mention-reply/SKILL.md` - `## User Token の設定方法` → `## トークン設定`（user-setup 参照）
- `profile-update/SKILL.md` - `### User Token の設定` の MCP 設定 JSON を user-setup 参照に簡素化
- `plugin.json` / `marketplace.json` を 4.1.0 → 4.1.1 に更新

## 関連 Issue

Closes #169

## テスト計画

- [ ] `grep -r "SLACK_BOT_TOKEN" plugins/shiiman-slack/skills/` で 0 件であることを確認
- [ ] 修正後の各 SKILL.md が `/shiiman-slack:user-setup` を参照していることを確認