### PR TITLE
feat(shiiman-workflow): cmux ターミナル最優先追加・全ターミナル tab/workspace/window クローズ対応 (#179)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/README.md
+++ b/plugins/shiiman-workflow/README.md
@@ -132,8 +132,8 @@ Agent Team で Issue から PR まで並列実行する開発フロー。
 - `multi-issue` の MCP 使用部分を Agent Team 実行に置き換え
 - `claude --dangerously-skip-permissions` で Agent Team 実行
 - ターミナル起動は `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を使用（既存起動時は新規タブ、未起動時は新規ウィンドウ先頭タブ）
-- 承認時クリーンアップは `plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh` を使用（tmux は常に終了、window 起動時のみ terminal をクローズ）
-- ターミナル選択順は `ghostty -> iterm2 -> Terminal.app -> current shell`
+- 承認時クリーンアップは `plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh` を使用（tmux は常に終了、ターミナルの tab/workspace/window をクローズ）
+- ターミナル選択順は `cmux -> ghostty -> iterm2 -> Terminal.app -> current shell`
 - tmux メッセージ送信先 target は固定値ではなく tmux 実値から動的解決
 - 2 つの Agent Team スキルで共通利用する送信スクリプトは `plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh` を使用
 
@@ -158,8 +158,8 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 - no-git モードではブランチ作成と push 前提手順を行わない
 - 問題時は Agent Team に再指示してループ可能
 - ターミナル起動は `plugins/shiiman-workflow/scripts/open_tmux_terminal.sh` を使用（既存起動時は新規タブ、未起動時は新規ウィンドウ先頭タブ）
-- 承認時クリーンアップは `plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh` を使用（tmux は常に終了、window 起動時のみ terminal をクローズ）
-- ターミナル選択順は `ghostty -> iterm2 -> Terminal.app -> current shell`
+- 承認時クリーンアップは `plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh` を使用（tmux は常に終了、ターミナルの tab/workspace/window をクローズ）
+- ターミナル選択順は `cmux -> ghostty -> iterm2 -> Terminal.app -> current shell`
 - tmux メッセージ送信先 target は固定値ではなく tmux 実値から動的解決
 - 2 つの Agent Team スキルで共通利用する送信スクリプトは `plugins/shiiman-workflow/scripts/send_claude_tmux_message.sh` を使用
 
@@ -204,10 +204,11 @@ no-git モード: 計画書 → ターミナル + tmux 起動 → Agent Team 実
 - `CLAUDE_PLUGIN_ROOT` が利用可能なプラグイン実行コンテキストで実行
 - `claude` コマンドが利用可能
 - tmux がインストール済み
-- macOS で Ghostty または iTerm2 を推奨（未導入時は Terminal.app / 現在端末にフォールバック）
+- macOS で cmux、Ghostty、または iTerm2 を推奨（未導入時は Terminal.app / 現在端末にフォールバック）
 
 ## バージョン履歴
 
+- v4.1.0: cmux をターミナル最優先として追加（cmux → Ghostty → iTerm2 → Terminal.app → Current Shell）、全ターミナルで tab/workspace/window クローズに対応
 - v4.0.0: git/GitHub 操作を Skill 呼び出しに置き換え、issue-branch-pr-create スキルを追加、push を自動実行からコマンド提示に変更（破壊的変更）
 - v3.0.0: 全スキルから `workflow-` プレフィックスを除去しリネーム（破壊的変更）
 - v2.0.0: 全スキルを `workflow-*` 形式にリネーム（破壊的変更）

--- a/plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh
+++ b/plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh
@@ -24,6 +24,7 @@ WINDOW_CLOSE_SUPPORTED="0"
 ITERM_WINDOW_ID=""
 TERMINAL_WINDOW_ID=""
 GHOSTTY_PID=""
+CMUX_PID=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -70,6 +71,13 @@ warn() {
   echo "[cleanup_tmux_terminal][WARN] $*" >&2
 }
 
+escape_applescript() {
+  local value="${1:-}"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
+}
+
 load_state_file() {
   local key=""
   local value=""
@@ -93,12 +101,13 @@ load_state_file() {
       ITERM_WINDOW_ID) ITERM_WINDOW_ID="$value" ;;
       TERMINAL_WINDOW_ID) TERMINAL_WINDOW_ID="$value" ;;
       GHOSTTY_PID) GHOSTTY_PID="$value" ;;
+      CMUX_PID) CMUX_PID="$value" ;;
       *) ;;
     esac
   done < "$STATE_FILE"
 
   case "$TERMINAL_BACKEND" in
-    ""|ghostty|iterm2|terminal|current_shell) ;;
+    ""|cmux|ghostty|iterm2|terminal|current_shell) ;;
     *)
       warn "invalid TERMINAL_BACKEND in state file: $TERMINAL_BACKEND"
       TERMINAL_BACKEND=""
@@ -106,7 +115,7 @@ load_state_file() {
   esac
 
   case "$OPEN_MODE" in
-    ""|tab|window|current_shell) ;;
+    ""|tab|window|workspace|current_shell) ;;
     *)
       warn "invalid OPEN_MODE in state file: $OPEN_MODE"
       OPEN_MODE=""
@@ -135,6 +144,11 @@ load_state_file() {
     warn "invalid GHOSTTY_PID in state file: $GHOSTTY_PID"
     GHOSTTY_PID=""
   fi
+
+  if [[ -n "$CMUX_PID" && ! "$CMUX_PID" =~ ^[0-9]+$ ]]; then
+    warn "invalid CMUX_PID in state file: $CMUX_PID"
+    CMUX_PID=""
+  fi
 }
 
 kill_tmux_session() {
@@ -158,41 +172,100 @@ kill_tmux_session() {
 }
 
 close_ghostty_window() {
-  if [[ -z "$GHOSTTY_PID" ]]; then
-    warn "Ghostty PID is empty. window close is skipped."
-    return 0
+  local stdout=""
+  local applescript=""
+
+  # PID ベースで終了を試みる（window モードで PID がある場合）
+  if [[ -n "$GHOSTTY_PID" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY-RUN] close Ghostty: try PID $GHOSTTY_PID, then fallback to title match '$SESSION'"
+      return 0
+    fi
+
+    if kill -0 "$GHOSTTY_PID" 2>/dev/null; then
+      if kill -TERM "$GHOSTTY_PID" 2>/dev/null; then
+        return 0
+      fi
+      warn "failed to terminate Ghostty PID: $GHOSTTY_PID; trying AppleScript title match."
+    else
+      log "Ghostty PID is not running anymore: $GHOSTTY_PID; trying AppleScript title match."
+    fi
   fi
 
+  # フォールバック: ウィンドウタイトルで特定して Cmd+W（tab/window 共通）
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "[DRY-RUN] kill -TERM \"$GHOSTTY_PID\""
+    echo "[DRY-RUN] close Ghostty tab/window by title match: '$SESSION'"
     return 0
   fi
 
-  if ! kill -0 "$GHOSTTY_PID" 2>/dev/null; then
-    warn "Ghostty PID is not running anymore: $GHOSTTY_PID"
+  applescript=$(cat <<EOF
+tell application "System Events"
+    if exists process "Ghostty" then
+        tell process "Ghostty"
+            set windowList to windows
+            repeat with w in windowList
+                if name of w contains "$SESSION" then
+                    perform action "AXRaise" of w
+                    delay 0.3
+                    keystroke "w" using command down
+                    return "found"
+                end if
+            end repeat
+            return "not_found"
+        end tell
+    else if exists process "ghostty" then
+        tell process "ghostty"
+            set windowList to windows
+            repeat with w in windowList
+                if name of w contains "$SESSION" then
+                    perform action "AXRaise" of w
+                    delay 0.3
+                    keystroke "w" using command down
+                    return "found"
+                end if
+            end repeat
+            return "not_found"
+        end tell
+    else
+        return "not_running"
+    end if
+end tell
+EOF
+)
+
+  if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
+    warn "failed to close Ghostty tab/window by title match for session: $SESSION"
     return 0
   fi
 
-  if ! kill -TERM "$GHOSTTY_PID" 2>/dev/null; then
-    warn "failed to terminate Ghostty PID: $GHOSTTY_PID"
-  fi
+  case "$stdout" in
+    found)
+      log "Ghostty tab/window closed by title match: $SESSION"
+      ;;
+    not_found)
+      warn "Ghostty window with title containing '$SESSION' was not found."
+      ;;
+    not_running)
+      warn "Ghostty process is not running."
+      ;;
+    *)
+      warn "unexpected Ghostty close result: $stdout"
+      ;;
+  esac
 }
 
 close_iterm2_window() {
   local stdout=""
   local applescript=""
 
-  if [[ -z "$ITERM_WINDOW_ID" ]]; then
-    warn "iTerm2 window id is empty. window close is skipped."
-    return 0
-  fi
+  # window id ベースのクローズ（window モード）
+  if [[ -n "$ITERM_WINDOW_ID" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY-RUN] close iTerm2 window id $ITERM_WINDOW_ID"
+      return 0
+    fi
 
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "[DRY-RUN] close iTerm2 window id $ITERM_WINDOW_ID"
-    return 0
-  fi
-
-  applescript=$(cat <<EOF
+    applescript=$(cat <<EOF
 tell application "iTerm"
     if not (exists window id $ITERM_WINDOW_ID) then
         return "missing"
@@ -202,31 +275,72 @@ tell application "iTerm"
 end tell
 EOF
 )
-  if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
-    warn "failed to close iTerm2 window id: $ITERM_WINDOW_ID"
+    if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
+      warn "failed to close iTerm2 window id: $ITERM_WINDOW_ID"
+      return 0
+    fi
+
+    if [[ "$stdout" != "closed" ]]; then
+      warn "iTerm2 window was not closed (status: $stdout, id: $ITERM_WINDOW_ID)"
+    fi
     return 0
   fi
 
-  if [[ "$stdout" != "closed" ]]; then
-    warn "iTerm2 window was not closed (status: $stdout, id: $ITERM_WINDOW_ID)"
+  # フォールバック: セッション名でタブを検索してクローズ（tab モード）
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] close iTerm2 tab by session name match: '$SESSION'"
+    return 0
   fi
+
+  local escaped_session
+  escaped_session="$(escape_applescript "$SESSION")"
+  applescript=$(cat <<EOF
+tell application "iTerm"
+    repeat with w in windows
+        repeat with t in tabs of w
+            repeat with s in sessions of t
+                if name of s contains "$escaped_session" then
+                    close t
+                    return "found"
+                end if
+            end repeat
+        end repeat
+    end repeat
+    return "not_found"
+end tell
+EOF
+)
+
+  if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
+    warn "failed to close iTerm2 tab by session name match for: $SESSION"
+    return 0
+  fi
+
+  case "$stdout" in
+    found)
+      log "iTerm2 tab closed by session name match: $SESSION"
+      ;;
+    not_found)
+      warn "iTerm2 tab with session containing '$SESSION' was not found."
+      ;;
+    *)
+      warn "unexpected iTerm2 close result: $stdout"
+      ;;
+  esac
 }
 
 close_terminal_window() {
   local stdout=""
   local applescript=""
 
-  if [[ -z "$TERMINAL_WINDOW_ID" ]]; then
-    warn "Terminal.app window id is empty. window close is skipped."
-    return 0
-  fi
+  # window id ベースのクローズ（window モード）
+  if [[ -n "$TERMINAL_WINDOW_ID" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY-RUN] close Terminal.app window id $TERMINAL_WINDOW_ID"
+      return 0
+    fi
 
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "[DRY-RUN] close Terminal.app window id $TERMINAL_WINDOW_ID"
-    return 0
-  fi
-
-  applescript=$(cat <<EOF
+    applescript=$(cat <<EOF
 tell application "Terminal"
     if not (exists window id $TERMINAL_WINDOW_ID) then
         return "missing"
@@ -236,37 +350,163 @@ tell application "Terminal"
 end tell
 EOF
 )
-  if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
-    warn "failed to close Terminal.app window id: $TERMINAL_WINDOW_ID"
+    if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
+      warn "failed to close Terminal.app window id: $TERMINAL_WINDOW_ID"
+      return 0
+    fi
+
+    if [[ "$stdout" != "closed" ]]; then
+      warn "Terminal.app window was not closed (status: $stdout, id: $TERMINAL_WINDOW_ID)"
+    fi
     return 0
   fi
 
-  if [[ "$stdout" != "closed" ]]; then
-    warn "Terminal.app window was not closed (status: $stdout, id: $TERMINAL_WINDOW_ID)"
+  # フォールバック: ウィンドウタイトルで特定して Cmd+W（tab モード）
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] close Terminal.app tab by title match: '$SESSION'"
+    return 0
   fi
+
+  applescript=$(cat <<EOF
+tell application "System Events"
+    if exists process "Terminal" then
+        tell process "Terminal"
+            set windowList to windows
+            repeat with w in windowList
+                if name of w contains "$SESSION" then
+                    perform action "AXRaise" of w
+                    delay 0.3
+                    keystroke "w" using command down
+                    return "found"
+                end if
+            end repeat
+            return "not_found"
+        end tell
+    else
+        return "not_running"
+    end if
+end tell
+EOF
+)
+
+  if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
+    warn "failed to close Terminal.app tab by title match for session: $SESSION"
+    return 0
+  fi
+
+  case "$stdout" in
+    found)
+      log "Terminal.app tab closed by title match: $SESSION"
+      ;;
+    not_found)
+      warn "Terminal.app window with title containing '$SESSION' was not found."
+      ;;
+    not_running)
+      warn "Terminal.app process is not running."
+      ;;
+    *)
+      warn "unexpected Terminal.app close result: $stdout"
+      ;;
+  esac
+}
+
+close_cmux_window() {
+  local stdout=""
+  local applescript=""
+
+  # PID ベースで終了を試みる
+  if [[ -n "$CMUX_PID" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY-RUN] close cmux window: try PID $CMUX_PID, then fallback to title match '$SESSION'"
+      return 0
+    fi
+
+    if kill -0 "$CMUX_PID" 2>/dev/null; then
+      if kill -TERM "$CMUX_PID" 2>/dev/null; then
+        return 0
+      fi
+      warn "failed to terminate cmux PID: $CMUX_PID; trying AppleScript title match."
+    else
+      log "cmux PID is not running anymore: $CMUX_PID; trying AppleScript title match."
+    fi
+  fi
+
+  # フォールバック: ウィンドウタイトルで特定して Cmd+W
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] close cmux window by title match: '$SESSION'"
+    return 0
+  fi
+
+  applescript=$(cat <<EOF
+tell application "System Events"
+    if exists process "cmux" then
+        tell process "cmux"
+            set windowList to windows
+            repeat with w in windowList
+                if name of w contains "$SESSION" then
+                    perform action "AXRaise" of w
+                    delay 0.3
+                    keystroke "w" using command down
+                    return "found"
+                end if
+            end repeat
+            return "not_found"
+        end tell
+    else
+        return "not_running"
+    end if
+end tell
+EOF
+)
+
+  if ! stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
+    warn "failed to close cmux window by title match for session: $SESSION"
+    return 0
+  fi
+
+  case "$stdout" in
+    found)
+      log "cmux window closed by title match: $SESSION"
+      ;;
+    not_found)
+      warn "cmux window with title containing '$SESSION' was not found."
+      ;;
+    not_running)
+      warn "cmux process is not running."
+      ;;
+    *)
+      warn "unexpected cmux close result: $stdout"
+      ;;
+  esac
 }
 
 kill_tmux_session
 load_state_file
 
-if [[ "$OPEN_MODE" != "window" ]]; then
-  log "open mode is '$OPEN_MODE'; window close is not required."
-  exit 0
-fi
-
-if [[ "$WINDOW_CLOSE_SUPPORTED" != "1" ]]; then
-  warn "window close is not supported for this launch state."
+if [[ "$OPEN_MODE" == "current_shell" || -z "$OPEN_MODE" ]]; then
+  log "open mode is '$OPEN_MODE'; terminal close is not applicable."
   exit 0
 fi
 
 case "$TERMINAL_BACKEND" in
+  cmux)
+    # window: PID kill → タイトルマッチ Cmd+W フォールバック
+    # workspace: タイトルマッチ Cmd+W（PID なしのため直接フォールバック）
+    close_cmux_window
+    ;;
   ghostty)
+    # window: PID kill → タイトルマッチ Cmd+W フォールバック
+    # tab: タイトルマッチ Cmd+W（PID なしのため直接フォールバック）
     close_ghostty_window
     ;;
   iterm2)
+    # window: window id ベースのクローズ
+    # tab: セッション名マッチでタブクローズ
     close_iterm2_window
     ;;
   terminal)
+    # window: window id ベースのクローズ
+    # tab: タイトルマッチ Cmd+W
     close_terminal_window
     ;;
   current_shell|"")

--- a/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
+++ b/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  open_tmux_terminal.sh --session <name> --repo-root <path> [--terminal <auto|ghostty|iterm2|terminal>] [--state-file <path>] [--dry-run]
+  open_tmux_terminal.sh --session <name> --repo-root <path> [--terminal <auto|cmux|ghostty|iterm2|terminal>] [--state-file <path>] [--dry-run]
 
 Options:
   --session <name>      tmux session name (allowed: [A-Za-z0-9._:-])
   --repo-root <path>    repository root path
-  --terminal <value>    auto | ghostty | iterm2 | terminal (default: auto)
+  --terminal <value>    auto | cmux | ghostty | iterm2 | terminal (default: auto)
   --state-file <path>   write launch metadata for cleanup script
   --dry-run             print selected behavior without opening terminals
   -h, --help            show this help
@@ -28,6 +28,7 @@ STATE_WINDOW_CLOSE_SUPPORTED="0"
 STATE_ITERM_WINDOW_ID=""
 STATE_TERMINAL_WINDOW_ID=""
 STATE_GHOSTTY_PID=""
+STATE_CMUX_PID=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -89,7 +90,7 @@ if [[ -n "$STATE_FILE" ]]; then
 fi
 
 case "$TERMINAL" in
-  auto|ghostty|iterm2|terminal)
+  auto|cmux|ghostty|iterm2|terminal)
     ;;
   *)
     echo "invalid --terminal value: $TERMINAL" >&2
@@ -110,6 +111,7 @@ record_state() {
   STATE_ITERM_WINDOW_ID="${4:-}"
   STATE_TERMINAL_WINDOW_ID="${5:-}"
   STATE_GHOSTTY_PID="${6:-}"
+  STATE_CMUX_PID="${7:-}"
 }
 
 write_state_file() {
@@ -125,6 +127,7 @@ WINDOW_CLOSE_SUPPORTED=$STATE_WINDOW_CLOSE_SUPPORTED
 ITERM_WINDOW_ID=$STATE_ITERM_WINDOW_ID
 TERMINAL_WINDOW_ID=$STATE_TERMINAL_WINDOW_ID
 GHOSTTY_PID=$STATE_GHOSTTY_PID
+CMUX_PID=$STATE_CMUX_PID
 EOF
 }
 
@@ -152,6 +155,172 @@ escape_applescript() {
   value="${value//\"/\\\"}"
   printf '%s' "$value"
 }
+
+# --- cmux ---
+
+get_cmux_path() {
+  local cmux_path
+  cmux_path="$(command -v cmux 2>/dev/null || true)"
+  if [[ -n "$cmux_path" ]]; then
+    printf '%s' "$cmux_path"
+    return 0
+  fi
+  if [[ -f "/Applications/cmux.app/Contents/MacOS/cmux" ]]; then
+    printf '%s' "/Applications/cmux.app/Contents/MacOS/cmux"
+    return 0
+  fi
+  return 1
+}
+
+is_cmux_available() {
+  get_cmux_path >/dev/null 2>&1 || [[ -d "/Applications/cmux.app" ]]
+}
+
+is_cmux_running() {
+  local stdout
+  local applescript
+  applescript=$(
+    cat <<'EOF'
+if application "cmux" is running then
+    return "true"
+else
+    return "false"
+end if
+EOF
+  )
+  if stdout="$(osascript -e "$applescript" 2>/dev/null)"; then
+    [[ "$stdout" == "true" ]]
+    return
+  fi
+  pgrep -x cmux >/dev/null 2>&1
+}
+
+collect_cmux_pids() {
+  pgrep -x cmux 2>/dev/null | awk 'NF { print $0 }' | sort -u
+}
+
+pick_new_cmux_pid() {
+  local before="$1"
+  local after="$2"
+  local pid
+  while IFS= read -r pid; do
+    [[ -n "$pid" ]] || continue
+    if ! printf '%s\n' "$before" | grep -Fxq "$pid"; then
+      printf '%s' "$pid"
+      return 0
+    fi
+  done <<< "$after"
+  return 1
+}
+
+open_cmux_workspace() {
+  local escaped_cmd
+  escaped_cmd="$(escape_applescript "$TMUX_CMD")"
+  local applescript
+  applescript=$(cat <<EOF
+set the clipboard to "$escaped_cmd"
+tell application "cmux"
+    activate
+end tell
+tell application "System Events"
+    if exists process "cmux" then
+        tell process "cmux"
+            keystroke "n" using command down
+            delay 0.5
+            keystroke "v" using command down
+            delay 0.1
+            keystroke return
+        end tell
+    else
+        error "cmux process not found"
+    end if
+end tell
+EOF
+)
+  osascript -e "$applescript" >/dev/null 2>&1
+}
+
+open_cmux_new_window() {
+  local cmux_path
+  cmux_path="$(get_cmux_path 2>/dev/null || true)"
+
+  local script_file
+  script_file="$(mktemp /tmp/cmux_session_XXXXXX.sh)"
+  cat >| "$script_file" <<SCRIPT
+#!/bin/bash
+tmux new-session -A -s "$SESSION" -c "$REPO_ROOT"
+SCRIPT
+  chmod +x "$script_file"
+
+  if [[ -n "$cmux_path" ]]; then
+    "$cmux_path" --working-directory="$REPO_ROOT" --title="$SESSION" -e "$script_file" &
+    disown
+  elif [[ -d "/Applications/cmux.app" ]]; then
+    open -na cmux.app --args --working-directory="$REPO_ROOT" --title="$SESSION" -e "$script_file" >/dev/null 2>&1
+  else
+    rm -f "$script_file"
+    return 1
+  fi
+}
+
+open_in_cmux() {
+  local before_pids=""
+  local after_pids=""
+  local cmux_pid=""
+
+  if ! is_cmux_available; then
+    return 1
+  fi
+
+  if is_cmux_running; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY-RUN] cmux is running: open new workspace and run: $TMUX_CMD"
+      record_state "cmux" "workspace" "0"
+      return 0
+    fi
+    if open_cmux_workspace; then
+      if wait_for_tmux_session 15 0.2; then
+        echo "Opened tmux in a new cmux workspace."
+        record_state "cmux" "workspace" "0"
+        return 0
+      fi
+      log "cmux workspace command was sent, but tmux session '$SESSION' was not created."
+    else
+      log "cmux workspace open failed."
+    fi
+    log "Falling back to a new cmux window."
+  fi
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[DRY-RUN] cmux is not running: open new window and run: $TMUX_CMD"
+    record_state "cmux" "window" "0"
+    return 0
+  fi
+
+  before_pids="$(collect_cmux_pids)"
+  if ! open_cmux_new_window; then
+    log "cmux new-window launch failed."
+    return 1
+  fi
+  if ! wait_for_tmux_session 25 0.2; then
+    log "cmux new-window command finished, but tmux session '$SESSION' was not created."
+    return 1
+  fi
+
+  after_pids="$(collect_cmux_pids)"
+  cmux_pid="$(pick_new_cmux_pid "$before_pids" "$after_pids" || true)"
+  if [[ -n "$cmux_pid" ]]; then
+    record_state "cmux" "window" "1" "" "" "" "$cmux_pid"
+  else
+    log "WARN: cmux window PID could not be identified. window cleanup will be skipped."
+    record_state "cmux" "window" "0"
+  fi
+
+  echo "Opened tmux in a new cmux window."
+  return 0
+}
+
+# --- Ghostty ---
 
 collect_ghostty_pids() {
   {
@@ -428,6 +597,14 @@ open_in_current_shell() {
 OPENED=0
 
 case "$TERMINAL" in
+  cmux)
+    if open_in_cmux; then
+      OPENED=1
+    else
+      echo "failed to open in cmux" >&2
+      exit 1
+    fi
+    ;;
   ghostty)
     if open_in_ghostty; then
       OPENED=1
@@ -453,14 +630,16 @@ case "$TERMINAL" in
     fi
     ;;
   auto)
-    if open_in_ghostty; then
+    if open_in_cmux; then
+      OPENED=1
+    elif open_in_ghostty; then
       OPENED=1
     elif open_in_iterm2; then
       OPENED=1
     elif open_in_terminal_app; then
       OPENED=1
     else
-      echo "Ghostty/iTerm2/Terminal.app unavailable. Falling back to current shell."
+      echo "cmux/Ghostty/iTerm2/Terminal.app unavailable. Falling back to current shell."
       if open_in_current_shell; then
         OPENED=1
       fi

--- a/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
@@ -54,7 +54,7 @@ Agent Team で Issue 作成から PR 作成までを並列実行するフロー�
 - `claude` コマンドが利用可能
 - `tmux` が利用可能
 - `gh auth status` が成功する（GitHub CLI 認証済み）
-- macOS で `Ghostty` または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
+- macOS で `cmux`、`Ghostty`、または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
 
 ## 実行フロー
 

--- a/plugins/shiiman-workflow/skills/agent-team/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team/SKILL.md
@@ -57,7 +57,7 @@ Agent Team で Issue/PR なしに並列実装を進める軽量フロー。
 - `tmux` が利用可能
 - `gh` コマンドが利用可能
 - `gh auth status` が成功する（GitHub CLI 認証済み）
-- macOS で `Ghostty` または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
+- macOS で `cmux`、`Ghostty`、または `iTerm2` を推奨（未導入時は `Terminal.app` / 現在端末へフォールバック）
 
 ## 実行モード判定（重要）
 


### PR DESCRIPTION
## 概要

shiiman-workflow の agent-team / agent-team-issue スキルが使用するターミナル起動・クリーンアップスクリプトに cmux サポートを追加し、全ターミナルの tab/workspace/window クローズに対応。

## 変更内容

### cmux サポート追加（`open_tmux_terminal.sh`）
- cmux 検出・起動関数群を追加（get_cmux_path, is_cmux_available, is_cmux_running, collect_cmux_pids, pick_new_cmux_pid, open_cmux_workspace, open_cmux_new_window, open_in_cmux）
- ターミナル選択優先順位を `cmux → Ghostty → iTerm2 → Terminal.app → Current Shell` に変更
- record_state / write_state_file に CMUX_PID を追加

### 全ターミナル tab/workspace/window クローズ対応（`cleanup_tmux_terminal.sh`）
- close_cmux_window 関数を追加（PID kill → AppleScript タイトルマッチ Cmd+W フォールバック）
- close_ghostty_window を拡張（tab モード対応: AppleScript タイトルマッチ Cmd+W フォールバック追加）
- close_iterm2_window を拡張（tab モード対応: セッション名マッチでタブクローズ追加）
- close_terminal_window を拡張（tab モード対応: System Events タイトルマッチ Cmd+W フォールバック追加）
- OPEN_MODE ガードを `current_shell` のみスキップに変更（以前は `window` 以外全てスキップ）
- escape_applescript 関数を追加

### ドキュメント・バージョン
- SKILL.md（agent-team, agent-team-issue）の前提条件に cmux を追加
- README.md のターミナル選択順・必要条件・バージョン履歴を更新
- plugin.json / marketplace.json のバージョンを 4.0.1 → 4.1.0 にバンプ

## 関連 Issue

Closes #179

## テスト計画

- [ ] `bash open_tmux_terminal.sh --session test --repo-root /tmp --dry-run` で cmux が優先選択されることを確認
- [ ] `bash open_tmux_terminal.sh --session test --repo-root /tmp --terminal cmux --dry-run` で明示指定が動作することを確認
- [ ] `bash cleanup_tmux_terminal.sh --session test --dry-run` で全ターミナルの dry-run を確認
- [ ] cmux インストール済み環境で実際にターミナル起動を確認

## チェックリスト

- [x] 命名規則に従っている
- [x] README.md を更新した
- [x] 動作確認済み（dry-run）