### PR TITLE
feat(shiiman-workflow): agent-team/agent-team-issue に --teammate-mode tmux を追加 (#185)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
@@ -113,7 +113,7 @@ bash "$OPEN_TMUX_SCRIPT" \
 ### ステップ 4: tmux 内で Claude Code を起動
 
 ```bash
-claude --dangerously-skip-permissions
+claude --dangerously-skip-permissions --teammate-mode tmux
 ```
 
 ### ステップ 5: 送信スクリプトを設定（multi-agent-mcp の送信方式）

--- a/plugins/shiiman-workflow/skills/agent-team/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team/SKILL.md
@@ -140,7 +140,7 @@ bash "$OPEN_TMUX_SCRIPT" \
 ### ステップ 5: tmux 内で Claude Code を起動
 
 ```bash
-claude --dangerously-skip-permissions
+claude --dangerously-skip-permissions --teammate-mode tmux
 ```
 
 ### ステップ 6: 送信スクリプトを設定（multi-agent-mcp の送信方式）


### PR DESCRIPTION
## 概要

agent-team と agent-team-issue スキルの Claude Code 起動コマンドに `--teammate-mode tmux` オプションを追加。
Agent Team のチームメンバーが tmux 分割ペインで表示され、同時監視・直接対話が可能になる。

## 変更内容

- agent-team/SKILL.md: `claude --dangerously-skip-permissions` → `claude --dangerously-skip-permissions --teammate-mode tmux`
- agent-team-issue/SKILL.md: 同上
- plugin.json / marketplace.json: バージョン 4.1.0 → 4.2.0

## 関連 Issue

Closes #185

## テスト計画

- [ ] `/shiiman-workflow:agent-team --help` でヘルプが正常表示されること
- [ ] `npm run format:check` が通ること
- [ ] agent-team スキル実行時に `--teammate-mode tmux` 付きで Claude Code が起動されること

## チェックリスト

- [x] 命名規則に従っている
- [x] 動作確認済み