### PR TITLE
feat(shiiman-workflow): agent-team に --no-review フラグと完了前レビュー自動修正を追加 (v4.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team-issue/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools:
   ]
 context: fork
 user-invocable: true
-argument-hint: "[タスク説明] [--plan|--branch|--help]"
+argument-hint: "[タスク説明] [--plan|--branch|--no-review|--help]"
 ---
 
 # Agent Team Issue Flow
@@ -39,15 +39,17 @@ Agent Team で Issue 作成から PR 作成までを並列実行するフロー�
   /shiiman-workflow:agent-team-issue [タスク説明] [オプション]
 
 オプション:
-  --plan    plan mode で計画書を新規作成してから実行
-  --branch  worktree の代わりにブランチを作成
-  --help    このヘルプを表示
+  --plan       plan mode で計画書を新規作成してから実行
+  --branch     worktree の代わりにブランチを作成
+  --no-review  完了報告前の shiiman-common:review をスキップ
+  --help       このヘルプを表示
 
 例:
   /shiiman-workflow:agent-team-issue                        # 既存計画書から実行（worktree）
   /shiiman-workflow:agent-team-issue --plan                 # 計画書を作成してから実行
   /shiiman-workflow:agent-team-issue --branch               # ブランチ作成モードで実行
   /shiiman-workflow:agent-team-issue "認証機能を並列実装"    # タスク説明から直接実行
+  /shiiman-workflow:agent-team-issue --no-review            # レビューをスキップして実行
 ```
 
 ## 前提条件
@@ -155,6 +157,10 @@ SEND_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/send_claude_tmux_message.sh"
 ```bash
 REPO_ROOT="$(pwd)"
 COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+REVIEW_NOTICE=""
+if [ "{no_review_flag}" != "true" ]; then
+  REVIEW_NOTICE="/shiiman-common:review を実行して指摘内容をすべて自動修正し、"
+fi
 
 # 計画書をファイルに保存
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -175,7 +181,7 @@ ${COMMIT_NOTICE}
 計画書ファイル: ${PLAN_FILE}
 Read ツールで上記ファイルを読み込んでから実装を進めてください。
 
-完了時は以下を報告してください。
+実装完了後、${REVIEW_NOTICE}以下を報告してください。
 - 実装サマリー
 - 変更ファイル
 - テスト結果
@@ -316,6 +322,10 @@ PR マージ後、不要になった worktree を削除してください:
 USER_FEEDBACK="{user_feedback}"
 REPO_ROOT="$(pwd)"
 COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
+REVIEW_NOTICE=""
+if [ "{no_review_flag}" != "true" ]; then
+  REVIEW_NOTICE="/shiiman-common:review を実行して指摘内容をすべて自動修正し、"
+fi
 
 # 修正依頼をファイルに保存
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -336,7 +346,7 @@ ${COMMIT_NOTICE}
 修正依頼ファイル: ${FIX_REQUEST_FILE}
 Read ツールで上記ファイルを読み込んでから修正を進めてください。
 
-上記を反映し、完了時は実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
+上記を反映し、${REVIEW_NOTICE}実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
 完了時は以下コマンドを実行して macOS 通知を送ってください。
 osascript -e 'display notification "Agent Team Issue 修正対応が完了しました" with title "workflow-agent-team-issue" sound name "default"'
 EOF

--- a/plugins/shiiman-workflow/skills/agent-team/SKILL.md
+++ b/plugins/shiiman-workflow/skills/agent-team/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools:
   ]
 context: fork
 user-invocable: true
-argument-hint: "[タスク説明] [--plan|--branch|--no-git|--help]"
+argument-hint: "[タスク説明] [--plan|--branch|--no-git|--no-review|--help]"
 ---
 
 # Agent Team Flow
@@ -39,10 +39,11 @@ Agent Team で Issue/PR なしに並列実装を進める軽量フロー。
   /shiiman-workflow:agent-team [タスク説明] [オプション]
 
 オプション:
-  --plan    plan mode で計画書を新規作成してから実行
-  --branch  worktree の代わりにブランチを作成
-  --no-git  git を使わず no-git モードで実行
-  --help    このヘルプを表示
+  --plan       plan mode で計画書を新規作成してから実行
+  --branch     worktree の代わりにブランチを作成
+  --no-git     git を使わず no-git モードで実行
+  --no-review  完了報告前の shiiman-common:review をスキップ
+  --help       このヘルプを表示
 
 例:
   /shiiman-workflow:agent-team                        # 既存計画書から実行（worktree）
@@ -50,6 +51,7 @@ Agent Team で Issue/PR なしに並列実装を進める軽量フロー。
   /shiiman-workflow:agent-team --branch               # ブランチ作成モードで実行
   /shiiman-workflow:agent-team "API リファクタリング"  # タスク説明から直接実行
   /shiiman-workflow:agent-team --no-git               # git なしモードで実行
+  /shiiman-workflow:agent-team --no-review            # レビューをスキップして実行
 ```
 
 ## 前提条件
@@ -188,6 +190,10 @@ COMMIT_NOTICE=""
 if [ "$FLOW_MODE" = "git" ]; then
   COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 fi
+REVIEW_NOTICE=""
+if [ "{no_review_flag}" != "true" ]; then
+  REVIEW_NOTICE="/shiiman-common:review を実行して指摘内容をすべて自動修正し、"
+fi
 
 # 計画書をファイルに保存
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -208,7 +214,7 @@ ${COMMIT_NOTICE}
 計画書ファイル: ${PLAN_FILE}
 Read ツールで上記ファイルを読み込んでから実装を進めてください。
 
-完了時は以下を報告してください。
+実装完了後、${REVIEW_NOTICE}以下を報告してください。
 - 実装サマリー
 - 変更ファイル
 - テスト結果
@@ -348,6 +354,10 @@ COMMIT_NOTICE=""
 if [ "$FLOW_MODE" = "git" ]; then
   COMMIT_NOTICE="コミット（git add / commit / push）は行わないでください。"
 fi
+REVIEW_NOTICE=""
+if [ "{no_review_flag}" != "true" ]; then
+  REVIEW_NOTICE="/shiiman-common:review を実行して指摘内容をすべて自動修正し、"
+fi
 
 # 修正依頼をファイルに保存
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -368,7 +378,7 @@ ${COMMIT_NOTICE}
 修正依頼ファイル: ${FIX_REQUEST_FILE}
 Read ツールで上記ファイルを読み込んでから修正を進めてください。
 
-上記を反映し、完了時は実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
+上記を反映し、${REVIEW_NOTICE}実装サマリー・変更ファイル・テスト結果・残課題を再報告してください。
 完了時は以下コマンドを実行して macOS 通知を送ってください。
 osascript -e 'display notification "Agent Team 修正対応が完了しました" with title "workflow-agent-team" sound name "default"'
 EOF


### PR DESCRIPTION
## 概要

`shiiman-workflow` の `agent-team`・`agent-team-issue` スキルに、Agent Team が完了報告前に `/shiiman-common:review` を実行して指摘内容を自動修正する機能を追加。
`--no-review` フラグでレビューをスキップできるようにした。

## 変更内容

- `agent-team` / `agent-team-issue`: 初回実装・修正依頼の完了報告前に `/shiiman-common:review` を実行して自動修正するよう Agent Team への指示を追加
- `--no-review` フラグを追加し、スキップ時は `REVIEW_NOTICE` を空にすることで命令文に自然に埋め込む形で制御
- `argument-hint`・ヘルプ・使用例に `--no-review` を追記
- plugin.json / marketplace.json バージョンを v4.3.1 → v4.4.0 に更新

## 関連 Issue

Closes #199

## テスト計画

- [ ] `--no-review` なしで実行し、Agent Team がレビューを実施してから報告することを確認
- [ ] `--no-review` ありで実行し、レビューをスキップして報告することを確認
- [ ] ヘルプ表示（`--help`）に `--no-review` が表示されることを確認

## チェックリスト

- [x] 命名規則に従っている
- [x] plugin.json と marketplace.json のバージョンが一致している
- [x] 動作確認済み