### PR TITLE
fix(shiiman-workflow): cmux 統合を CLI ベース（new-workspace）に刷新し外部アクセス権限を追加（v4.4.1）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,7 +40,7 @@
     {
       "name": "shiiman-workflow",
       "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "source": "./plugins/shiiman-workflow",
       "category": "developer-tools"
     },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,7 @@
     "allow": [
       "Bash(git fetch:*)",
       "Bash(git checkout:*)",
+      "Bash(git checkout *)",
       "Bash(git pull:*)",
       "Bash(git branch:*)",
       "Bash(git push -u origin feature/:*)",
@@ -23,6 +24,11 @@
       "Bash(gh run:*)",
       "Bash(python:*)",
       "Bash(python3:*)",
+      "Bash(make lint-all)",
+      "Bash(make lint-go)",
+      "Bash(go vet *)",
+      "Bash(tmux list-sessions *)",
+      "Bash(cmux ping)",
       "Skill(*)"
     ],
     "deny": [

--- a/plugins/shiiman-workflow/.claude-plugin/plugin.json
+++ b/plugins/shiiman-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shiiman-workflow",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "開発ワークフロー自動化 - シングル/マルチエージェント/Agent Team での Issue 管理付き・なしのフローを提供",
   "author": {
     "name": "shiiman"

--- a/plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh
+++ b/plugins/shiiman-workflow/scripts/cleanup_tmux_terminal.sh
@@ -413,8 +413,23 @@ EOF
 close_cmux_window() {
   local stdout=""
   local applescript=""
+  local cmux_path=""
+  cmux_path="$(command -v cmux 2>/dev/null || true)"
 
-  # PID ベースで終了を試みる
+  # CLI でワークスペースをクローズ（workspace モード）
+  if [[ "$OPEN_MODE" == "workspace" && -n "$cmux_path" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "[DRY-RUN] cmux close-workspace --workspace \"$SESSION\""
+      return 0
+    fi
+    if "$cmux_path" close-workspace --workspace "$SESSION" >/dev/null 2>&1; then
+      log "cmux workspace closed via CLI: $SESSION"
+      return 0
+    fi
+    warn "cmux close-workspace failed; falling back to title match."
+  fi
+
+  # PID ベースで終了を試みる（window モード / フォールバック）
   if [[ -n "$CMUX_PID" ]]; then
     if [[ "$DRY_RUN" -eq 1 ]]; then
       echo "[DRY-RUN] close cmux window: try PID $CMUX_PID, then fallback to title match '$SESSION'"

--- a/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
+++ b/plugins/shiiman-workflow/scripts/open_tmux_terminal.sh
@@ -195,128 +195,49 @@ EOF
   pgrep -x cmux >/dev/null 2>&1
 }
 
-collect_cmux_pids() {
-  pgrep -x cmux 2>/dev/null | awk 'NF { print $0 }' | sort -u
-}
-
-pick_new_cmux_pid() {
-  local before="$1"
-  local after="$2"
-  local pid
-  while IFS= read -r pid; do
-    [[ -n "$pid" ]] || continue
-    if ! printf '%s\n' "$before" | grep -Fxq "$pid"; then
-      printf '%s' "$pid"
-      return 0
-    fi
-  done <<< "$after"
-  return 1
-}
-
-open_cmux_workspace() {
-  local escaped_cmd
-  escaped_cmd="$(escape_applescript "$TMUX_CMD")"
-  local applescript
-  applescript=$(cat <<EOF
-set the clipboard to "$escaped_cmd"
-tell application "cmux"
-    activate
-end tell
-tell application "System Events"
-    if exists process "cmux" then
-        tell process "cmux"
-            keystroke "n" using command down
-            delay 0.5
-            keystroke "v" using command down
-            delay 0.1
-            keystroke return
-        end tell
-    else
-        error "cmux process not found"
-    end if
-end tell
-EOF
-)
-  osascript -e "$applescript" >/dev/null 2>&1
-}
-
-open_cmux_new_window() {
-  local cmux_path
-  cmux_path="$(get_cmux_path 2>/dev/null || true)"
-
-  local script_file
-  script_file="$(mktemp /tmp/cmux_session_XXXXXX.sh)"
-  cat >| "$script_file" <<SCRIPT
-#!/bin/bash
-tmux new-session -A -s "$SESSION" -c "$REPO_ROOT"
-SCRIPT
-  chmod +x "$script_file"
-
-  if [[ -n "$cmux_path" ]]; then
-    "$cmux_path" --working-directory="$REPO_ROOT" --title="$SESSION" -e "$script_file" &
-    disown
-  elif [[ -d "/Applications/cmux.app" ]]; then
-    open -na cmux.app --args --working-directory="$REPO_ROOT" --title="$SESSION" -e "$script_file" >/dev/null 2>&1
-  else
-    rm -f "$script_file"
-    return 1
-  fi
-}
-
 open_in_cmux() {
-  local before_pids=""
-  local after_pids=""
-  local cmux_pid=""
-
   if ! is_cmux_available; then
     return 1
   fi
 
-  if is_cmux_running; then
-    if [[ "$DRY_RUN" -eq 1 ]]; then
-      echo "[DRY-RUN] cmux is running: open new workspace and run: $TMUX_CMD"
-      record_state "cmux" "workspace" "0"
-      return 0
-    fi
-    if open_cmux_workspace; then
-      if wait_for_tmux_session 15 0.2; then
-        echo "Opened tmux in a new cmux workspace."
-        record_state "cmux" "workspace" "0"
-        return 0
-      fi
-      log "cmux workspace command was sent, but tmux session '$SESSION' was not created."
-    else
-      log "cmux workspace open failed."
-    fi
-    log "Falling back to a new cmux window."
-  fi
+  local cmux_path
+  cmux_path="$(get_cmux_path 2>/dev/null || true)"
+  [[ -n "$cmux_path" ]] || return 1
 
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "[DRY-RUN] cmux is not running: open new window and run: $TMUX_CMD"
-    record_state "cmux" "window" "0"
+    echo "[DRY-RUN] cmux new-workspace --cwd \"$REPO_ROOT\" --name \"$SESSION\" --command \"$TMUX_CMD\""
+    record_state "cmux" "workspace" "0"
     return 0
   fi
 
-  before_pids="$(collect_cmux_pids)"
-  if ! open_cmux_new_window; then
-    log "cmux new-window launch failed."
+  if ! is_cmux_running; then
+    log "cmux is not running. Launching cmux..."
+    open -a cmux.app >/dev/null 2>&1 || return 1
+    local i
+    for ((i = 0; i < 20; i++)); do
+      if "$cmux_path" ping >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.5
+    done
+    if ! "$cmux_path" ping >/dev/null 2>&1; then
+      log "cmux did not start in time."
+      return 1
+    fi
+  fi
+
+  if ! "$cmux_path" new-workspace --cwd "$REPO_ROOT" --name "$SESSION" --command "$TMUX_CMD" >/dev/null 2>&1; then
+    log "cmux new-workspace failed."
     return 1
   fi
+
   if ! wait_for_tmux_session 25 0.2; then
-    log "cmux new-window command finished, but tmux session '$SESSION' was not created."
+    log "cmux new-workspace was sent, but tmux session '$SESSION' was not created."
     return 1
   fi
 
-  after_pids="$(collect_cmux_pids)"
-  cmux_pid="$(pick_new_cmux_pid "$before_pids" "$after_pids" || true)"
-  if [[ -n "$cmux_pid" ]]; then
-    record_state "cmux" "window" "1" "" "" "" "$cmux_pid"
-  else
-    log "WARN: cmux window PID could not be identified. window cleanup will be skipped."
-    record_state "cmux" "window" "0"
-  fi
-
-  echo "Opened tmux in a new cmux window."
+  record_state "cmux" "workspace" "0"
+  echo "Opened tmux in a new cmux workspace."
   return 0
 }
 


### PR DESCRIPTION
## 概要

cmux のバージョンアップによりソケット接続のセキュリティが強化され、外部プロセスからの CLI 接続が拒否されるようになった問題に対応。

- cmux の `socketControlMode` を `allowAll` に設定し外部接続を許可
- `open_tmux_terminal.sh` の cmux 統合を正しい CLI（`cmux new-workspace`）に刷新
- `cleanup_tmux_terminal.sh` の cmux クリーンアップを `cmux close-workspace` CLI 優先に更新
- `.claude/settings.json` に `git checkout *`・lint・vet コマンドの権限を追加

## 変更詳細

### scripts/open_tmux_terminal.sh

- `open_cmux_workspace`（AppleScript クリップボード方式）を削除
- `open_cmux_new_window`（誤フラグ `--working-directory`/`--title`/`-e` を使用）を削除
- `open_in_cmux` を `cmux new-workspace --cwd ... --name ... --command ...` に一本化
- cmux 未起動時は `open -a cmux.app` で起動してからソケット待機する処理を追加

### scripts/cleanup_tmux_terminal.sh

- `close_cmux_window` に `cmux close-workspace --workspace "$SESSION"` CLI クローズを優先追加
- 失敗時は既存の AppleScript タイトルマッチにフォールバック

### .claude/settings.json

- `Bash(git checkout *)` — スペース形式追加（ブランチ作成の権限エラー修正）
- `Bash(make lint-all)` / `Bash(make lint-go)` — 頻出リントコマンド
- `Bash(go vet *)` — Go 静的解析
- `Bash(tmux list-sessions *)` — tmux セッション一覧
- `Bash(cmux ping)` — cmux 疎通確認

## テスト計画

- [ ] cmux 起動中に `cmux ping` が PONG を返すことを確認
- [ ] `cmux new-workspace` でワークスペース・tmux セッションが作成されることを確認
- [ ] `/shiiman-workflow:agent-team-issue` 等のフローで cmux ターミナルが正常に開くことを確認

## 関連 Issue

Close #202